### PR TITLE
T565 parse addresses [part 1]

### DIFF
--- a/arretify/step_consolidation/operations_detection.py
+++ b/arretify/step_consolidation/operations_detection.py
@@ -18,7 +18,7 @@
 #
 from typing import List, Iterator
 
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 
 from arretify.regex_utils import (
     regex_tree,
@@ -319,7 +319,7 @@ def parse_operations(
 def _render_operation_match(
     soup: BeautifulSoup,
     operation_match: regex_tree.Match,
-):
+) -> Tag:
     return make_data_tag(
         soup,
         OPERATION_SCHEMA,

--- a/arretify/step_segmentation/__step__.py
+++ b/arretify/step_segmentation/__step__.py
@@ -16,11 +16,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from typing import List, cast
+
+
 from arretify.types import DocumentContext
-from .parse_arrete import parse_arrete
+from .parse_arrete import parse_arrete, render_arrete
+from .core import NodeOrText
 
 
 def step_segmentation(document_context: DocumentContext) -> DocumentContext:
     if not document_context.lines:
         raise ValueError("Parsing context does not contain any lines to segment")
-    return parse_arrete(document_context)
+
+    body = document_context.soup.body
+    assert body
+
+    lines = document_context.lines
+    assert lines
+
+    body.extend(
+        render_arrete(
+            document_context.soup,
+            parse_arrete(cast(List[NodeOrText], lines)),
+        )
+    )
+
+    return document_context

--- a/arretify/step_segmentation/basic_elements.py
+++ b/arretify/step_segmentation/basic_elements.py
@@ -62,10 +62,12 @@ from .core import (
     Node,
     NodeOrText,
     is_node,
-    make_single_line_splitter_for_text_segments,
-    assert_single_text_segment,
+    make_single_line_splitter_for_text_span_nodes,
+    get_string,
+    get_strings,
+    combine_text_spans,
     make_probe_from_pattern_proxy,
-    pick_text_segment,
+    pick_text_span_node,
     pick_if_inline_node_followed_by_match,
 )
 from .document_elements import render_table_of_contents, render_page_footer, render_page_separator
@@ -81,19 +83,17 @@ A match for the table splitter, in the form `(<table_elements>, <table_descripti
 """
 
 _is_table = make_probe_from_pattern_proxy(TABLE_LINE_PATTERN)
-_is_table_start = pick_text_segment(_is_table)
-_is_table_end = negate(pick_if_inline_node_followed_by_match(pick_text_segment(_is_table)))
+_is_table_start = pick_text_span_node(_is_table)
+_is_table_end = negate(pick_if_inline_node_followed_by_match(pick_text_span_node(_is_table)))
 
 
-def _make_table_description_end_probe(table_lines: List[TextSegment]) -> Probe[NodeOrText]:
+def _make_table_description_end_probe(table_lines: List[str]) -> Probe[NodeOrText]:
     def _is_table_description(elements: List[NodeOrText], index: int) -> bool:
-        element = elements[index]
-        assert isinstance(element, TextSegment)
-        if is_table_description(element.contents, [t.contents for t in table_lines]):
+        if is_table_description(get_string(elements[index]), table_lines):
             return True
         return False
 
-    return negate(pick_text_segment(_is_table_description))
+    return negate(pick_text_span_node(_is_table_description))
 
 
 def parse_tables(
@@ -120,17 +120,20 @@ def _table_splitter(
     table_pile, input_list = split_before_match(input_list, _is_table_end)
 
     if table_pile:
-        table_lines: List[TextSegment] = []
-        for element in table_pile:
-            if isinstance(element, TextSegment):
-                table_lines.append(element)
-
         # Directly after table end, look for table description.
         table_description_pile, input_list = split_before_match(
             input_list,
-            _make_table_description_end_probe(table_lines),
+            _make_table_description_end_probe(get_strings(table_pile)),
         )
-        return before, (table_pile, table_description_pile), input_list
+
+        return (
+            before,
+            (
+                table_pile,
+                table_description_pile,
+            ),
+            input_list,
+        )
     else:
         return None
 
@@ -143,9 +146,10 @@ def render_table(
     has_table_header = False
     inline_nodes: List[Tuple[int, Node]] = []
     for element in node.children:
-        if isinstance(element, TextSegment):
-            pile.append(element.contents)
-            if bool(TABLE_HEADER_SEPARATOR_PATTERN.match(element.contents)):
+        if is_node(element, type_in=["text_span"]):
+            element_str = get_string(element)
+            pile.append(element_str)
+            if bool(TABLE_HEADER_SEPARATOR_PATTERN.match(element_str)):
                 has_table_header = True
         elif is_node(element, type_in=["page_separator"]):
             table_tag = parse_markdown_table(pile)
@@ -178,9 +182,9 @@ def render_table_description(
     node: Node,
 ) -> Iterable[PageElementOrString]:
     for element in node.children:
-        if isinstance(element, TextSegment):
+        if is_node(element, type_in=["text_span"]):
             yield soup.new_tag("br")
-            yield element.contents
+            yield get_string(element)
         elif is_node(element, type_in=["page_separator"]):
             yield render_page_separator(soup, element)
         else:
@@ -193,11 +197,9 @@ def render_table_description(
 LEADING_WHITESPACES_PATTERN = PatternProxy(r"^\s+")
 """Detect leading whitespaces."""
 
-_is_list = make_probe_from_pattern_proxy(LIST_PATTERN)
-_is_list_start = pick_text_segment(_is_list)
-_is_inline_node_followed_by_list = pick_if_inline_node_followed_by_match(
-    pick_text_segment(_is_list)
-)
+_is_list_element = make_probe_from_pattern_proxy(LIST_PATTERN)
+_is_list_start = pick_text_span_node(_is_list_element)
+_is_list_continuation = pick_if_inline_node_followed_by_match(pick_text_span_node(_is_list_element))
 
 
 def _list_indentation(line: str) -> int:
@@ -228,27 +230,28 @@ def _list_splitter(
     pile: List[NodeOrText] = []
     while elements:
         element = elements[0]
-        if isinstance(element, TextSegment) and _is_list(elements, 0):
+
+        # This will pick either a list element, or an inline tag (e.g. page separator)
+        # that is followed by a list element.
+        if _is_list_continuation(elements, 0):
             pile.append(elements.pop(0))
 
-        # We want to keep inline node only if the list continues after it.
-        elif _is_inline_node_followed_by_list(elements, 0):
-            pile.append(elements.pop(0))
-
-        # If we get a TextSegment that does not match the list pattern,
+        # If we get a line that does not match the list pattern,
         # we check if it continues the previous sentence.
-        elif isinstance(element, TextSegment):
-            # First get the previous text segment in the pile.
+        elif is_node(element, type_in=["text_span"]):
+            # First get the previous list element in the pile.
             j = len(pile) - 1
-            while j >= 0 and not isinstance(pile[j], TextSegment):
+            while j >= 0 and not is_node(pile[j], type_in=["text_span"]):
                 j -= 1
             if j < 0:
-                raise RuntimeError("Expected a TextSegment before the current element in the pile.")
-            previous_text_segment = pile[j]
-            assert isinstance(previous_text_segment, TextSegment)
+                raise RuntimeError("Expected to find a list element in the pile.")
+            previous_list_element = pile[j]
 
-            if is_continuing_sentence(previous_text_segment.contents, element.contents):
-                pile[j] = Node(type="text_span", children=[*pile[j:], elements.pop(0)])
+            if is_continuing_sentence(
+                get_string(previous_list_element),
+                get_string(element),
+            ):
+                pile[j] = combine_text_spans([*pile[j:], elements.pop(0)])
             else:
                 break
 
@@ -290,7 +293,8 @@ def _render_list(
 ) -> Tuple[List[NodeOrText], Tag]:
     elements = list(elements)
     list_pile: List[Tag] = []
-    ref_indentation = _get_element_list_indentation(elements[0])
+    element = elements[0]
+    ref_indentation = _list_indentation(get_string(element))
 
     while elements:
         element = elements[0]
@@ -299,15 +303,11 @@ def _render_list(
             list_pile[-1].append(render_page_separator(soup, element))
             elements.pop(0)
 
-        elif isinstance(element, TextSegment) or is_node(element, type_in=["text_span"]):
-            current_indentation = _get_element_list_indentation(element)
-            li_contents: List[PageElementOrString] = []
-            if isinstance(element, TextSegment):
-                li_contents = [element.contents]
-            elif is_node(element, type_in=["text_span"]):
-                li_contents = list(render_text_span(soup, element))
+        elif is_node(element, type_in=["text_span", "text_span"]):
+            current_indentation = _list_indentation(get_string(element))
 
             if current_indentation == ref_indentation:
+                li_contents = list(render_text_span(soup, element))
                 if isinstance(li_contents[0], str):
                     li_contents[0] = _clean_leading_whitespaces(li_contents[0])
                 list_pile.append(make_new_tag(soup, "li", contents=li_contents))
@@ -328,18 +328,6 @@ def _render_list(
     return elements, make_new_tag(soup, "ul", contents=list_pile)
 
 
-def _get_element_list_indentation(
-    element: NodeOrText,
-) -> int:
-    if isinstance(element, TextSegment):
-        return _list_indentation(element.contents)
-    elif is_node(element, type_in=["text_span"]):
-        assert isinstance(element.children[0], TextSegment)
-        return _list_indentation((element.children[0]).contents)
-    else:
-        raise RuntimeError(f"Expected a TextSegment or text_span node, got {element}.")
-
-
 # -------------------- Blockquotes -------------------- #
 _BlockquoteSplitterMatch = Tuple[List[NodeOrText], ErrorCodes | None]
 """
@@ -356,9 +344,10 @@ DOUBLE_QUOTE_PATTERN = PatternProxy(r'"')
 """Basic double quote '"' pattern."""
 
 
-_is_blockquote_start = make_probe_from_pattern_proxy(BLOCKQUOTE_START_PATTERN)
-_is_blockquote_start_text_segment = pick_text_segment(_is_blockquote_start)
-_is_blockquote_end = make_probe_from_pattern_proxy(BLOCKQUOTE_END_PATTERN, use_search=True)
+_is_blockquote_start = pick_text_span_node(make_probe_from_pattern_proxy(BLOCKQUOTE_START_PATTERN))
+_is_blockquote_end = pick_text_span_node(
+    make_probe_from_pattern_proxy(BLOCKQUOTE_END_PATTERN, use_search=True)
+)
 
 
 def parse_blockquotes(
@@ -376,10 +365,10 @@ def parse_blockquotes(
 def _make_blockquote_node(match: _BlockquoteSplitterMatch) -> Node:
     pile, error_code = match
     if error_code is None:
-        elements = chain_functions(pile, [parse_tables, parse_lists, parse_images])
+        children = chain_functions(pile, [parse_tables, parse_lists, parse_images])
         return Node(
             type="blockquote",
-            children=list(elements),
+            children=children,
         )
     else:
         return Node(
@@ -392,31 +381,31 @@ def _make_blockquote_node(match: _BlockquoteSplitterMatch) -> Node:
 def _blockquote_splitter(
     input_list: List[NodeOrText],
 ) -> RawSplit[NodeOrText, _BlockquoteSplitterMatch] | None:
-    before, input_list = split_before_match(input_list, _is_blockquote_start_text_segment)
+    before, input_list = split_before_match(input_list, _is_blockquote_start)
 
     if not input_list:
         return None
 
     # At this point, we know that the first element is a blockquote start
-    assert isinstance(input_list[0], TextSegment)
-    opening_quote_start = input_list[0].start
-
+    element = input_list[0]
+    assert is_node(element, type_in=["text_span"])
+    first_text_segment_index, first_text_segment = _get_first_text_segment(element)
     # Remove opening quote
     # TODO-PROCESS-TAG
-    input_list[0] = apply_to_segment(
-        input_list[0],
+    element.children[first_text_segment_index] = apply_to_segment(
+        first_text_segment,
         lambda string: BLOCKQUOTE_START_PATTERN.sub("", string),
     )
     quotes_depth_count = 1
 
     for i, element in enumerate(input_list):
-        if not isinstance(element, TextSegment):
+        if not is_node(element, type_in=["text_span"]):
             continue
 
         # Ignore case when the line contains a balanced number of quotes.
         # In that case, no need to increment or decrement as this will
         # be handled recursively.
-        double_quotes_matches = list(DOUBLE_QUOTE_PATTERN.finditer(element.contents))
+        double_quotes_matches = list(DOUBLE_QUOTE_PATTERN.finditer(get_string(element)))
         if len(double_quotes_matches) % 2 == 0:
             pass
         else:
@@ -425,10 +414,11 @@ def _blockquote_splitter(
             if _is_blockquote_end(input_list, i):
                 quotes_depth_count -= 1
             if quotes_depth_count <= 0:
+                last_text_segment_index, last_text_segment = _get_last_text_segment(element)
                 # Remove the end quote
                 # TODO-PROCESS-TAG
-                input_list[i] = apply_to_segment(
-                    element,
+                element.children[last_text_segment_index] = apply_to_segment(
+                    last_text_segment,
                     lambda string: BLOCKQUOTE_END_PATTERN.sub("", string),
                 )
                 break
@@ -437,8 +427,26 @@ def _blockquote_splitter(
         # Last line should be included, so we take `i + 1`
         return before, (input_list[: i + 1], None), input_list[i + 1 :]
     else:
-        _LOGGER.warning(f"Found unbalanced quote starting {opening_quote_start}")
+        _LOGGER.warning(f"Found unbalanced quote starting {first_text_segment.start}")
         return before, (input_list[0:1], ErrorCodes.unbalanced_quote), input_list[1:]
+
+
+def _get_first_text_segment(
+    text_span_node: Node,
+) -> Tuple[int, TextSegment]:
+    for i, element in enumerate(text_span_node.children):
+        if isinstance(element, TextSegment):
+            return i, element
+    raise ValueError("No text segment found.")
+
+
+def _get_last_text_segment(
+    text_span_node: Node,
+) -> Tuple[int, TextSegment]:
+    for i, element in enumerate(reversed(text_span_node.children)):
+        if isinstance(element, TextSegment):
+            return len(text_span_node.children) - 1 - i, element
+    raise ValueError("No text segment found.")
 
 
 def render_blockquote(
@@ -447,14 +455,19 @@ def render_blockquote(
 ) -> Iterable[PageElementOrString]:
     tag = soup.new_tag("blockquote")
     for element in node.children:
-        if isinstance(element, Node):
-            tag.extend(render_basic_elements(soup, element))
-        else:
-            # Parse inline quotes in the line
-            # and add them as <q> tags
+        if is_node(element, type_in=["text_span"]):
             tag.append(
-                make_new_tag(soup, "p", contents=render_inline_quotes(soup, element.contents))
+                make_new_tag(
+                    soup,
+                    "p",
+                    # TODO : should be parsed like other nodes, instead of being
+                    # rendered here on the fly. This would also make parsing blockquote easier.
+                    contents=render_inline_quotes(soup, get_string(element)),
+                )
             )
+        elif is_node(element):
+            tag.extend(render_basic_elements(soup, element))
+
     yield tag
 
 
@@ -468,9 +481,9 @@ def parse_images(
     return map_splitted_elements(
         split_elements(
             input_list,
-            make_single_line_splitter_for_text_segments(_is_image),
+            make_single_line_splitter_for_text_span_nodes(_is_image),
         ),
-        lambda pile: Node(type="image", children=pile),
+        lambda children: Node(type="image", children=children),
     )
 
 
@@ -478,7 +491,7 @@ def render_image(
     soup: BeautifulSoup,
     node: Node,
 ) -> Tag:
-    return parse_markdown_image(assert_single_text_segment(node).contents)
+    return parse_markdown_image(get_string(node))
 
 
 # -------------------- Misc -------------------- #
@@ -533,6 +546,8 @@ def render_basic_elements(
         yield render_image(soup, node)
     elif node.type == "error":
         yield render_error(soup, node)
+    elif node.type == "text_span":
+        yield from render_text_span(soup, node)
     else:
         raise ValueError(f"Unknown node type '{node.type}' in render_basic_elements.")
 
@@ -545,5 +560,5 @@ def render_error(
         soup,
         ERROR_SCHEMA,
         data=dict(error_codes=render_str_list_attribute(node.data["error_codes"])),
-        contents=[assert_single_text_segment(node).contents],
+        contents=[get_string(n) for n in node.children],
     )

--- a/arretify/step_segmentation/basic_elements.py
+++ b/arretify/step_segmentation/basic_elements.py
@@ -303,7 +303,7 @@ def _render_list(
             list_pile[-1].append(render_page_separator(soup, element))
             elements.pop(0)
 
-        elif is_node(element, type_in=["text_span", "text_span"]):
+        elif is_node(element, type_in=["text_span"]):
             current_indentation = _list_indentation(get_string(element))
 
             if current_indentation == ref_indentation:

--- a/arretify/step_segmentation/basic_elements_test.py
+++ b/arretify/step_segmentation/basic_elements_test.py
@@ -26,12 +26,13 @@ from .basic_elements import (
     parse_lists,
     parse_tables,
     parse_blockquotes,
+    parse_images,
     render_inline_quotes,
     render_table,
     render_table_description,
     render_list,
 )
-from .testing import assert_elements_equal, _l
+from .testing import assert_elements_equal, _l, make_text_spans
 from arretify.utils.testing import normalized_html_str, assert_html_list_equal
 
 
@@ -73,7 +74,7 @@ class TestParseTables(unittest.TestCase):
 
     def test_simple_table(self):
         # Arrange
-        elements = _l(
+        elements = make_text_spans(
             "| Polluant | Concentration maximale en mg/l |",
             "|---------|---------------------------------|",
             "| MES     | 35                               |",
@@ -91,7 +92,7 @@ class TestParseTables(unittest.TestCase):
             [
                 Node(
                     type="table",
-                    children=_l(
+                    children=make_text_spans(
                         "| Polluant | Concentration maximale en mg/l |",
                         "|---------|---------------------------------|",
                         "| MES     | 35                               |",
@@ -99,13 +100,13 @@ class TestParseTables(unittest.TestCase):
                         "| Hydrocarbures totaux | 10                             |",
                     ),
                 ),
-                *_l("END"),
+                *make_text_spans("END"),
             ],
         )
 
     def test_table_description(self):
         # Arrange
-        elements = _l(
+        elements = make_text_spans(
             "| Polluant | Concentration maximale en mg/l |",
             "|---------|---------------------------------|",
             "| MES     | 35                               |",
@@ -123,7 +124,7 @@ class TestParseTables(unittest.TestCase):
             [
                 Node(
                     type="table",
-                    children=_l(
+                    children=make_text_spans(
                         "| Polluant | Concentration maximale en mg/l |",
                         "|---------|---------------------------------|",
                         "| MES     | 35                               |",
@@ -131,16 +132,18 @@ class TestParseTables(unittest.TestCase):
                 ),
                 Node(
                     type="table_description",
-                    children=_l("(*) bla bla", "Polluant : Matières en suspension (MES)"),
+                    children=make_text_spans(
+                        "(*) bla bla", "Polluant : Matières en suspension (MES)"
+                    ),
                 ),
-                *_l("END"),
+                *make_text_spans("END"),
             ],
         )
 
     def test_parse_tables_with_node_at_end(self):
         # Arrange
         elements = [
-            *_l(
+            *make_text_spans(
                 "| Polluant | Concentration maximale en mg/l |",
                 "|---------|---------------------------------|",
                 "| MES     | 35                               |",
@@ -151,7 +154,7 @@ class TestParseTables(unittest.TestCase):
                 children=[],
                 data=dict(page_index=1),
             ),
-            *_l("END"),
+            *make_text_spans("END"),
         ]
 
         # Act
@@ -163,7 +166,7 @@ class TestParseTables(unittest.TestCase):
             [
                 Node(
                     type="table",
-                    children=_l(
+                    children=make_text_spans(
                         "| Polluant | Concentration maximale en mg/l |",
                         "|---------|---------------------------------|",
                         "| MES     | 35                               |",
@@ -175,7 +178,7 @@ class TestParseTables(unittest.TestCase):
                     children=[],
                     data=dict(page_index=1),
                 ),
-                *_l("END"),
+                *make_text_spans("END"),
             ],
         )
 
@@ -184,7 +187,7 @@ class TestParseList(unittest.TestCase):
 
     def test_simple_list(self):
         # Arrange
-        elements = _l("- Item 1", "- Item 2", "- Item 3", "END")
+        elements = make_text_spans("- Item 1", "- Item 2", "- Item 3", "END")
 
         # Act
         result = parse_lists(elements)
@@ -195,15 +198,15 @@ class TestParseList(unittest.TestCase):
             [
                 Node(
                     type="list",
-                    children=_l("- Item 1", "- Item 2", "- Item 3"),
+                    children=make_text_spans("- Item 1", "- Item 2", "- Item 3"),
                 ),
-                *_l("END"),
+                *make_text_spans("END"),
             ],
         )
 
     def test_nested_list(self):
         # Arrange
-        elements = _l(
+        elements = make_text_spans(
             "- Item 1",
             "  - Subitem 1.1",
             "  - Subitem 1.2",
@@ -219,14 +222,16 @@ class TestParseList(unittest.TestCase):
             [
                 Node(
                     type="list",
-                    children=_l("- Item 1", "  - Subitem 1.1", "  - Subitem 1.2", "- Item 2"),
+                    children=make_text_spans(
+                        "- Item 1", "  - Subitem 1.1", "  - Subitem 1.2", "- Item 2"
+                    ),
                 ),
             ],
         )
 
     def test_text_segment_continuing_previous_sentence(self):
         # Arrange
-        elements = _l(
+        elements = make_text_spans(
             "- Item 1",
             "this is a continuation of the previous sentence.",
             "- Item 2",
@@ -249,10 +254,10 @@ class TestParseList(unittest.TestCase):
                                 "- Item 1", "this is a continuation of the previous sentence."
                             ),
                         ),
-                        *_l("- Item 2"),
+                        *make_text_spans("- Item 2"),
                     ],
                 ),
-                *_l("END"),
+                *make_text_spans("END"),
             ],
         )
 
@@ -263,7 +268,7 @@ class TestParseBlockQuote(unittest.TestCase):
         # Arrange
         elements = [
             Node(type="some_node", children=[]),
-            *_l(
+            *make_text_spans(
                 '"This is',
                 'a blockquote"',
                 "END",
@@ -280,15 +285,15 @@ class TestParseBlockQuote(unittest.TestCase):
                 Node(type="some_node", children=[]),
                 Node(
                     type="blockquote",
-                    children=_l("This is", "a blockquote"),
+                    children=make_text_spans("This is", "a blockquote"),
                 ),
-                *_l("END"),
+                *make_text_spans("END"),
             ],
         )
 
     def test_blockquote_nested_list(self):
         # Arrange
-        lines = _l(
+        lines = make_text_spans(
             '"bla bla',
             "blo blo :",
             "- Item 1",
@@ -306,26 +311,26 @@ class TestParseBlockQuote(unittest.TestCase):
                 Node(
                     type="blockquote",
                     children=[
-                        *_l(
+                        *make_text_spans(
                             "bla bla",
                             "blo blo :",
                         ),
                         Node(
                             type="list",
-                            children=_l(
+                            children=make_text_spans(
                                 "- Item 1",
                                 "- Item 2",
                             ),
                         ),
                     ],
                 ),
-                *_l("END"),
+                *make_text_spans("END"),
             ],
         )
 
     def test_blockquote_one_liner_nested_blockquote(self):
         # Arrange
-        elements = _l(
+        elements = make_text_spans(
             '"bla bla',
             '"blo blo"',
             'bli bli"',
@@ -341,15 +346,15 @@ class TestParseBlockQuote(unittest.TestCase):
             [
                 Node(
                     type="blockquote",
-                    children=_l("bla bla", '"blo blo"', "bli bli"),
+                    children=make_text_spans("bla bla", '"blo blo"', "bli bli"),
                 ),
-                *_l("END"),
+                *make_text_spans("END"),
             ],
         )
 
     def test_blockquote_nested_inline_quote(self):
         # Arrange
-        elements = _l(
+        elements = make_text_spans(
             '"bla bla',
             'blo blo "haha"',
             'bli bli"',
@@ -365,19 +370,19 @@ class TestParseBlockQuote(unittest.TestCase):
             [
                 Node(
                     type="blockquote",
-                    children=_l(
+                    children=make_text_spans(
                         "bla bla",
                         'blo blo "haha"',
                         "bli bli",
                     ),
                 ),
-                *_l("END"),
+                *make_text_spans("END"),
             ],
         )
 
     def test_blockquote_one_line(self):
         # Arrange
-        elements = _l(
+        elements = make_text_spans(
             '"bla bla"',
             "END",
         )
@@ -391,9 +396,9 @@ class TestParseBlockQuote(unittest.TestCase):
             [
                 Node(
                     type="blockquote",
-                    children=_l("bla bla"),
+                    children=make_text_spans("bla bla"),
                 ),
-                *_l("END"),
+                *make_text_spans("END"),
             ],
         )
 
@@ -428,13 +433,13 @@ class TestRenderTable(unittest.TestCase):
         node = Node(
             type="table",
             children=[
-                *_l("| Column 1 | Column 2 |", "|----------|----------|"),
+                *make_text_spans("| Column 1 | Column 2 |", "|----------|----------|"),
                 Node(
                     type="page_separator",
                     children=[],
                     data=dict(page_index=1),
                 ),
-                *_l(
+                *make_text_spans(
                     "| Row 1    | Data 1   |",
                 ),
                 Node(
@@ -442,7 +447,7 @@ class TestRenderTable(unittest.TestCase):
                     children=[],
                     data=dict(page_index=2),
                 ),
-                *_l(
+                *make_text_spans(
                     "| Row 2    | Data 2   |",
                 ),
             ],
@@ -486,13 +491,13 @@ class TestRenderTableDescription(unittest.TestCase):
         node = Node(
             type="table_description",
             children=[
-                *_l("This is a description of the table."),
+                *make_text_spans("This is a description of the table."),
                 Node(
                     type="page_separator",
                     children=[],
                     data=dict(page_index=1),
                 ),
-                *_l("This is another part of the description."),
+                *make_text_spans("This is another part of the description."),
             ],
         )
 
@@ -521,13 +526,13 @@ class TestRenderList(unittest.TestCase):
         node = Node(
             type="list",
             children=[
-                *_l("- Item 1"),
+                *make_text_spans("- Item 1"),
                 Node(
                     type="page_separator",
                     children=[],
                     data=dict(page_index=1),
                 ),
-                *_l("- Item 2"),
+                *make_text_spans("- Item 2"),
             ],
         )
 
@@ -549,7 +554,7 @@ class TestRenderList(unittest.TestCase):
         node = Node(
             type="list",
             children=[
-                *_l("- Item 1", "  - Subitem 1.1", "  - Subitem 1.2", "- Item 2"),
+                *make_text_spans("- Item 1", "  - Subitem 1.1", "  - Subitem 1.2", "- Item 2"),
             ],
         )
 
@@ -580,7 +585,7 @@ class TestRenderList(unittest.TestCase):
                     type="text_span",
                     children=_l("- Item 1", "This is a continuation of the previous sentence."),
                 ),
-                *_l("- Item 2"),
+                *make_text_spans("- Item 2"),
             ],
         )
 
@@ -595,4 +600,30 @@ class TestRenderList(unittest.TestCase):
                 <li>- Item 2</li>
             </ul>
             """
+        )
+
+
+class TestParseImage(unittest.TestCase):
+
+    def test_parse_image(self):
+        # Arrange
+        elements = make_text_spans(
+            "![Image description](image_url.jpg)",
+            "END",
+        )
+
+        # Act
+        result = parse_images(elements)
+
+        # Assert
+        assert_elements_equal(
+            result,
+            [
+                Node(
+                    type="image",
+                    data=dict(),
+                    children=make_text_spans("![Image description](image_url.jpg)"),
+                ),
+                *make_text_spans("END"),
+            ],
         )

--- a/arretify/step_segmentation/content.py
+++ b/arretify/step_segmentation/content.py
@@ -117,7 +117,7 @@ def parse_section_titles(
 ) -> List[NodeOrText]:
     # First fix titles containing alinea
     # Do it only if we are not in lite mode as this is computation intensive
-    if not lite:
+    if lite is False:
         elements = _fix_titles_containing_alineas(elements)
 
     # Then collect all section titles in list
@@ -204,11 +204,16 @@ def parse_section_titles(
 @iter_func_to_list
 def _fix_titles_containing_alineas(elements: List[NodeOrText]) -> Iterator[NodeOrText]:
     for element in elements:
-        if not isinstance(element, TextSegment) or not TITLE_NODE.pattern.match(element.contents):
+        if not is_node(element, type_in=["text_span"]):
             yield element
             continue
 
-        section_name, text = parse_title_text(element.contents)
+        title_string = get_string(element)
+        if not TITLE_NODE.pattern.match(title_string):
+            yield element
+            continue
+
+        section_name, text = parse_title_text(title_string)
         result = split_at_first_verb(text)
         if result is None:
             yield element
@@ -220,9 +225,23 @@ def _fix_titles_containing_alineas(elements: List[NodeOrText]) -> Iterator[NodeO
             title_text = section_name
         else:
             title_text = section_name + title_text
-        title_end = (element.end[0], element.end[1], len(title_text))
-        yield TextSegment(contents=title_text, start=element.start, end=title_end)
-        yield TextSegment(contents=alinea_text, start=title_end, end=element.end)
+
+        # TODO : fix TextSegments start / end
+        assert len(element.children) == 1 and isinstance(element.children[0], TextSegment)
+        text_segment: TextSegment = element.children[0]
+        title_end = (text_segment.end[0], text_segment.end[1], len(title_text))
+        yield Node(
+            type="text_span",
+            children=[
+                TextSegment(contents=title_text, start=text_segment.start, end=title_end),
+            ],
+        )
+        yield Node(
+            type="text_span",
+            children=[
+                TextSegment(contents=alinea_text, start=title_end, end=text_segment.end),
+            ],
+        )
 
 
 def _create_section_title_nodes(

--- a/arretify/step_segmentation/content.py
+++ b/arretify/step_segmentation/content.py
@@ -60,9 +60,9 @@ from .core import (
     Node,
     NodeOrText,
     is_node,
-    assert_single_text_segment,
-    make_single_line_splitter_for_text_segments,
-    make_probe_from_pattern,
+    make_single_line_splitter_for_text_span_nodes,
+    make_probe_from_pattern_proxy,
+    get_string,
 )
 from .document_elements import (
     render_page_footer,
@@ -74,7 +74,7 @@ from .document_elements import (
 _LOGGER = logging.getLogger(__name__)
 
 
-_is_title = make_probe_from_pattern(
+_is_title = make_probe_from_pattern_proxy(
     TITLE_NODE.pattern,
 )
 
@@ -142,7 +142,7 @@ def parse_section_titles(
     current_schema_level = -1
 
     for section_title in section_titles:
-        title_text = assert_single_text_segment(section_title).contents
+        title_text = get_string(section_title)
         data_extra: Dict = dict()
 
         # Parse title info
@@ -231,11 +231,11 @@ def _create_section_title_nodes(
     return map_splitted_elements(
         split_elements(
             elements,
-            make_single_line_splitter_for_text_segments(_is_title),
+            make_single_line_splitter_for_text_span_nodes(_is_title),
         ),
-        lambda text_segments: Node(
+        lambda children: Node(
             type="section_title",
-            children=text_segments,
+            children=children,
         ),
     )
 
@@ -358,7 +358,7 @@ def render_section_title(
     return make_data_tag(
         soup,
         SECTION_TITLE_SCHEMAS[node.data["level"]],
-        contents=[assert_single_text_segment(node).contents],
+        contents=[get_string(node)],
         data=data,
     )
 
@@ -432,33 +432,32 @@ def parse_alineas(
             continue
 
         alinea_children: List[NodeOrText] = []
-        if isinstance(element, Node):
+        if is_node(element, type_in=["table"]):
             alinea_children = [element]
-            if element.type == "table":
-                while (
-                    elements
-                    and isinstance(elements[0], Node)
-                    and elements[0].type == "table_description"
-                ):
-                    alinea_children.append(elements[0])
-                    elements.pop(0)
+            while (
+                elements
+                and isinstance(elements[0], Node)
+                and elements[0].type == "table_description"
+            ):
+                alinea_children.append(elements[0])
+                elements.pop(0)
+
+        elif (
+            len(elements) >= 2
+            and is_node(element, type_in=["text_span"])
+            and is_node(elements[0], type_in=["page_separator"])
+            and is_node(elements[1], type_in=["text_span"])
+            and is_continuing_sentence(
+                get_string(element),
+                get_string(elements[1]),
+            )
+        ):
+            alinea_children = [element, elements[0], elements[1]]
+            elements.pop(0)
+            elements.pop(0)
 
         else:
-            if (
-                len(elements) >= 2
-                and is_node(elements[0], type_in=["page_separator"])
-                and isinstance(elements[1], TextSegment)
-                and is_continuing_sentence(
-                    element.contents,
-                    elements[1].contents,
-                )
-            ):
-                alinea_children = [element, elements[0], elements[1]]
-                elements.pop(0)
-                elements.pop(0)
-
-            else:
-                alinea_children = [element]
+            alinea_children = [element]
 
         yield Node(
             type="alinea",
@@ -476,7 +475,9 @@ def render_alinea(
 ) -> Tag:
     contents: List[PageElementOrString] = []
     for element in node.children:
-        if isinstance(element, Node):
+        if is_node(element, type_in=["text_span"]):
+            contents.extend(render_inline_quotes(soup, get_string(element)))
+        elif isinstance(element, Node):
             contents.extend(render_basic_elements(soup, element))
         else:
             contents.extend(render_inline_quotes(soup, element.contents))

--- a/arretify/step_segmentation/content_test.py
+++ b/arretify/step_segmentation/content_test.py
@@ -18,11 +18,15 @@
 #
 import unittest
 
-from .content import parse_section_titles, parse_sections, parse_alineas
+from bs4 import BeautifulSoup
+
+from arretify.utils.testing import normalized_html_str
+from .content import parse_section_titles, parse_sections, parse_alineas, render_alinea
 from .core import Node
 from .testing import (
     assert_elements_equal,
     _l,
+    make_text_spans,
 )
 
 
@@ -30,7 +34,7 @@ class TestParseSectionTitles(unittest.TestCase):
 
     def test_parse_section_titles(self):
         # Arrange
-        elements = _l(
+        elements = make_text_spans(
             "Titre I - Introduction",
             "1. Contexte",
             "bla bla bla",
@@ -51,7 +55,7 @@ class TestParseSectionTitles(unittest.TestCase):
             [
                 Node(
                     type="section_title",
-                    children=_l("Titre I - Introduction"),
+                    children=make_text_spans("Titre I - Introduction"),
                     data=dict(
                         level=0,
                         number="I",
@@ -61,7 +65,7 @@ class TestParseSectionTitles(unittest.TestCase):
                 ),
                 Node(
                     type="section_title",
-                    children=_l("1. Contexte"),
+                    children=make_text_spans("1. Contexte"),
                     data=dict(
                         level=1,
                         number="1",
@@ -69,10 +73,10 @@ class TestParseSectionTitles(unittest.TestCase):
                         type="unknown",
                     ),
                 ),
-                *_l("bla bla bla"),
+                *make_text_spans("bla bla bla"),
                 Node(
                     type="section_title",
-                    children=_l("2. Objectifs"),
+                    children=make_text_spans("2. Objectifs"),
                     data=dict(
                         level=1,
                         number="2",
@@ -80,13 +84,13 @@ class TestParseSectionTitles(unittest.TestCase):
                         type="unknown",
                     ),
                 ),
-                *_l(
+                *make_text_spans(
                     "blo blo blo",
                     "bli bli bli",
                 ),
                 Node(
                     type="section_title",
-                    children=_l("Titre II - Méthodologie"),
+                    children=make_text_spans("Titre II - Méthodologie"),
                     data=dict(
                         level=0,
                         number="II",
@@ -94,7 +98,7 @@ class TestParseSectionTitles(unittest.TestCase):
                         type="titre",
                     ),
                 ),
-                *_l(
+                *make_text_spans(
                     "blu blu blu",
                     "ble ble ble",
                 ),
@@ -107,33 +111,33 @@ class TestParseSections(unittest.TestCase):
     def test_parse_sections(self):
         # Arrange
         elements = [
-            *_l("bly bly bly"),
+            *make_text_spans("bly bly bly"),
             Node(
                 type="section_title",
                 data=dict(level=1),
-                children=_l("Titre I - Introduction"),
+                children=make_text_spans("Titre I - Introduction"),
             ),
             Node(
                 type="section_title",
                 data=dict(level=2),
-                children=_l("1. Contexte"),
+                children=make_text_spans("1. Contexte"),
             ),
-            *_l("bla bla bla"),
+            *make_text_spans("bla bla bla"),
             Node(
                 type="section_title",
                 data=dict(level=2),
-                children=_l("2. Objectifs"),
+                children=make_text_spans("2. Objectifs"),
             ),
-            *_l(
+            *make_text_spans(
                 "blo blo blo",
                 "bli bli bli",
             ),
             Node(
                 type="section_title",
                 data=dict(level=1),
-                children=_l("Titre II - Méthodologie"),
+                children=make_text_spans("Titre II - Méthodologie"),
             ),
-            *_l(
+            *make_text_spans(
                 "blu blu blu",
                 "ble ble ble",
             ),
@@ -148,7 +152,7 @@ class TestParseSections(unittest.TestCase):
             [
                 Node(
                     type="alinea",
-                    children=_l("bly bly bly"),
+                    children=make_text_spans("bly bly bly"),
                     data=dict(number="1"),
                 ),
                 Node(
@@ -156,15 +160,15 @@ class TestParseSections(unittest.TestCase):
                     children=[
                         Node(
                             type="section_title",
-                            children=_l("Titre I - Introduction"),
+                            children=make_text_spans("Titre I - Introduction"),
                         ),
                         Node(
                             type="section",
                             children=[
-                                Node(type="section_title", children=_l("1. Contexte")),
+                                Node(type="section_title", children=make_text_spans("1. Contexte")),
                                 Node(
                                     type="alinea",
-                                    children=_l("bla bla bla"),
+                                    children=make_text_spans("bla bla bla"),
                                     data=dict(number="1"),
                                 ),
                             ],
@@ -172,15 +176,17 @@ class TestParseSections(unittest.TestCase):
                         Node(
                             type="section",
                             children=[
-                                Node(type="section_title", children=_l("2. Objectifs")),
+                                Node(
+                                    type="section_title", children=make_text_spans("2. Objectifs")
+                                ),
                                 Node(
                                     type="alinea",
-                                    children=_l("blo blo blo"),
+                                    children=make_text_spans("blo blo blo"),
                                     data=dict(number="1"),
                                 ),
                                 Node(
                                     type="alinea",
-                                    children=_l("bli bli bli"),
+                                    children=make_text_spans("bli bli bli"),
                                     data=dict(number="2"),
                                 ),
                             ],
@@ -192,16 +198,16 @@ class TestParseSections(unittest.TestCase):
                     children=[
                         Node(
                             type="section_title",
-                            children=_l("Titre II - Méthodologie"),
+                            children=make_text_spans("Titre II - Méthodologie"),
                         ),
                         Node(
                             type="alinea",
-                            children=_l("blu blu blu"),
+                            children=make_text_spans("blu blu blu"),
                             data=dict(number="1"),
                         ),
                         Node(
                             type="alinea",
-                            children=_l("ble ble ble"),
+                            children=make_text_spans("ble ble ble"),
                             data=dict(number="2"),
                         ),
                     ],
@@ -402,13 +408,13 @@ class TestParseAlineas(unittest.TestCase):
     def test_merge_if_continuing_sentence_and_page_separator(self):
         # Arrange
         elements = [
-            *_l("This is a sentence that "),
+            *make_text_spans("This is a sentence that "),
             Node(
                 type="page_separator",
                 data=dict(page_index=1),
                 children=[],
             ),
-            *_l("continues on the next page."),
+            *make_text_spans("continues on the next page."),
         ]
 
         # Act
@@ -421,15 +427,41 @@ class TestParseAlineas(unittest.TestCase):
                 Node(
                     type="alinea",
                     children=[
-                        *_l("This is a sentence that "),
+                        *make_text_spans("This is a sentence that "),
                         Node(
                             type="page_separator",
                             data=dict(page_index=1),
                             children=[],
                         ),
-                        *_l("continues on the next page."),
+                        *make_text_spans("continues on the next page."),
                     ],
                     data=dict(number="1"),
                 ),
             ],
+        )
+
+
+class TestRenderAlinea(unittest.TestCase):
+
+    def setUp(self):
+        self.soup = BeautifulSoup("", features="html.parser")
+
+    def test_simple(self):
+        # Arrange
+        alinea = Node(
+            type="alinea",
+            children=make_text_spans("This is an alinea."),
+            data=dict(number="1"),
+        )
+
+        # Act
+        result = render_alinea(self.soup, alinea)
+
+        # Assert
+        assert normalized_html_str(str(result)) == normalized_html_str(
+            """
+            <div class="arretify-alinea" data-number="1">
+                This is an alinea.
+            </div>
+            """
         )

--- a/arretify/step_segmentation/core.py
+++ b/arretify/step_segmentation/core.py
@@ -23,11 +23,14 @@ from typing import (
     Any,
     Union,
     cast,
+    Iterator,
 )
 from dataclasses import dataclass, field
 
+from arretify.utils.functional import iter_func_to_list
 from arretify.types import TextSegment
 from arretify.regex_utils import PatternProxy
+from arretify.utils.strings import merge_strings
 from arretify.utils.split_merge import (
     make_while_splitter,
     make_single_line_splitter,
@@ -91,75 +94,63 @@ def pick_if_inline_node_followed_by_match(
     return _pick_inline_nodes_probe
 
 
-def pick_text_segment(
+def pick_text_span_node(
     probe: Probe[NodeOrText],
 ) -> Probe[NodeOrText]:
-    def _text_segment_probe(elements: List[NodeOrText], index: int) -> bool:
+    def _probe(elements: List[NodeOrText], index: int) -> bool:
         element = elements[index]
-        if isinstance(element, TextSegment):
+        if is_node(element, type_in=["text_span"]):
             return probe(elements, index)
         return False
 
-    return _text_segment_probe
+    return _probe
 
 
 def make_probe_from_pattern_proxy(
     pattern: PatternProxy, use_search: bool = False
 ) -> Probe[NodeOrText]:
     def _probe(elements: List[NodeOrText], index: int) -> bool:
-        element = elements[index]
-        assert isinstance(element, TextSegment)
+        string = get_string(elements[index])
         if use_search is False:
-            match = pattern.match(element.contents)
+            match = pattern.match(string)
         else:
-            match = pattern.search(element.contents)
+            match = pattern.search(string)
         return bool(match)
 
     return _probe
 
 
-def make_probe_from_pattern(
-    pattern: PatternProxy,
-) -> Probe[NodeOrText]:
-    def _probe(elements: List[NodeOrText], index: int) -> bool:
-        element = elements[index]
-        assert isinstance(element, TextSegment)
-        return bool(pattern.match(element.contents))
-
-    return _probe
-
-
-def make_while_splitter_for_text_segments(
+def make_while_splitter_for_text_span_nodes(
     start_condition: Probe[NodeOrText],
     while_condition: Probe[NodeOrText],
 ) -> Splitter[NodeOrText, List[NodeOrText]]:
     return make_while_splitter(
-        pick_text_segment(start_condition),
-        pick_if_inline_node_followed_by_match(pick_text_segment(while_condition)),
+        pick_text_span_node(start_condition),
+        pick_if_inline_node_followed_by_match(pick_text_span_node(while_condition)),
     )
 
 
-def make_single_line_splitter_for_text_segments(
+def make_single_line_splitter_for_text_span_nodes(
     is_matching: Probe[NodeOrText],
 ) -> Splitter[NodeOrText, List[NodeOrText]]:
     return make_single_line_splitter(
-        is_matching=pick_text_segment(is_matching),
+        is_matching=pick_text_span_node(is_matching),
     )
 
 
-group_text_segments_splitter = cast(
-    Splitter[NodeOrText, List[TextSegment]],
+group_text_span_nodes_splitter = cast(
+    Splitter[NodeOrText, List[NodeOrText]],
     make_while_splitter(
-        pick_text_segment(lambda elements, index: True),
-        pick_if_inline_node_followed_by_match(pick_text_segment(lambda elements, index: True)),
+        pick_text_span_node(lambda elements, index: True),
+        pick_if_inline_node_followed_by_match(pick_text_span_node(lambda elements, index: True)),
     ),
 )
 """
-Splitter to enable grouping of TextSegment elements.
+Splitter to enable grouping of text_span nodes.
 """
 
 
-def is_node(node: Node | TextSegment, type_in: List[str] | None = None) -> TypeGuard[Node]:
+def is_node(node: NodeOrText, type_in: List[str] | None = None) -> TypeGuard[Node]:
     if not isinstance(node, Node):
         return False
 
@@ -168,23 +159,71 @@ def is_node(node: Node | TextSegment, type_in: List[str] | None = None) -> TypeG
     return True
 
 
-def assert_single_text_segment(node: Node) -> TextSegment:
+def get_string(node: NodeOrText) -> str:
     """
-    Assert that the node contains exactly one TextSegment.
+    Extracts the string from a Node or TextSegment.
+    If the node is a TextSegment, it returns its contents.
+    If the node is a Node, it recursively extracts strings from its text_span children.
+    If its has other than text_span children, it will raises a ValueError.
     """
-    assert len(node.children) == 1 and isinstance(
-        node.children[0], TextSegment
-    ), f"Node '{node.type}' must contain exactly one TextSegment"
-    return node.children[0]
+    if isinstance(node, TextSegment):
+        return node.contents
+
+    strings: List[str] = []
+    for child in node.children:
+        if isinstance(child, TextSegment):
+            strings.append(child.contents)
+        else:
+            strings.append(_get_string(child))
+    return merge_strings(strings)
 
 
-def assert_all_text_segments(
-    node: Node,
-) -> List[TextSegment]:
+def _get_string(element: NodeOrText) -> str:
+    if isinstance(element, TextSegment):
+        return element.contents
+    elif is_node(element, type_in=["text_span"]):
+        return merge_strings(_get_string(child) for child in element.children)
+    elif is_node(element, type_in=INLINE_NODE_TYPES):
+        return ""
+    else:
+        raise ValueError(f"Unexpected element '{element}'")
+
+
+@iter_func_to_list
+def get_strings(nodes: List[NodeOrText]) -> Iterator[str]:
+    for node in nodes:
+        if is_node(node, type_in=["text_span"]):
+            yield get_string(node)
+        elif is_node(node, type_in=INLINE_NODE_TYPES):
+            continue
+        else:
+            raise ValueError(f"Node '{node}' is not a text_span or an inline node")
+
+
+def combine_text_spans(
+    elements: List[NodeOrText],
+) -> Node:
     """
-    Assert that all children of the node are TextSegment.
+    Combines a list of TextSegments and text_span nodes into a single text_span node.
     """
-    assert all(
-        isinstance(child, TextSegment) for child in node.children
-    ), f"Node '{node.type}' must contain only TextSegment"
-    return cast(List[TextSegment], node.children)
+    children: List[NodeOrText] = []
+    for element in elements:
+        if is_node(element, type_in=["text_span"]):
+            for text_span_child in element.children:
+                if isinstance(text_span_child, TextSegment) or is_node(
+                    text_span_child, type_in=INLINE_NODE_TYPES
+                ):
+                    children.append(text_span_child)
+                else:
+                    raise ValueError(f"Unexpected child '{text_span_child}' in of text_span node")
+
+        elif is_node(element, type_in=INLINE_NODE_TYPES):
+            children.append(element)
+
+        else:
+            raise ValueError(f"Unexpected element '{element}' ")
+
+    return Node(
+        type="text_span",
+        children=children,
+    )

--- a/arretify/step_segmentation/core.py
+++ b/arretify/step_segmentation/core.py
@@ -168,10 +168,7 @@ def get_string(node: NodeOrText) -> str:
     """
     if isinstance(node, TextSegment):
         return node.contents
-
-    strings: List[str] = []
-    for child in node.children:
-        strings.append(_get_string(child))
+    strings: List[str] = [_get_string(child) for child in node.children]
     return merge_strings(strings)
 
 

--- a/arretify/step_segmentation/core.py
+++ b/arretify/step_segmentation/core.py
@@ -171,10 +171,7 @@ def get_string(node: NodeOrText) -> str:
 
     strings: List[str] = []
     for child in node.children:
-        if isinstance(child, TextSegment):
-            strings.append(child.contents)
-        else:
-            strings.append(_get_string(child))
+        strings.append(_get_string(child))
     return merge_strings(strings)
 
 

--- a/arretify/step_segmentation/core_test.py
+++ b/arretify/step_segmentation/core_test.py
@@ -18,15 +18,18 @@
 #
 import unittest
 
+from arretify.types import TextSegment
 from arretify.regex_utils import PatternProxy
 from .core import (
-    make_while_splitter_for_text_segments,
-    pick_text_segment,
-    group_text_segments_splitter,
+    make_while_splitter_for_text_span_nodes,
+    pick_text_span_node,
+    group_text_span_nodes_splitter,
     Node,
     make_probe_from_pattern_proxy,
+    get_string,
+    combine_text_spans,
 )
-from .testing import _l
+from .testing import _l, make_text_spans
 
 
 class TestMakeTextSegmentWhileSplitter(unittest.TestCase):
@@ -34,15 +37,15 @@ class TestMakeTextSegmentWhileSplitter(unittest.TestCase):
     def test_rejects_non_text_segments(self):
         # Arrange
         def probe(elements, index):
-            return elements[index].contents.startswith("match")
+            return elements[index].children[0].contents.startswith("match")
 
-        splitter = make_while_splitter_for_text_segments(
+        splitter = make_while_splitter_for_text_span_nodes(
             probe,
             probe,
         )
         elements = [
             Node(type="non_text", children=[]),
-            *_l("match this"),
+            *make_text_spans("match this"),
             Node(type="another_non_text", children=[]),
         ]
 
@@ -55,13 +58,13 @@ class TestMakeTextSegmentWhileSplitter(unittest.TestCase):
     def test_match_found(self):
         # Arrange
         def probe(elements, index):
-            return elements[index].contents.startswith("match")
+            return elements[index].children[0].contents.startswith("match")
 
-        splitter = make_while_splitter_for_text_segments(
+        splitter = make_while_splitter_for_text_span_nodes(
             probe,
             probe,
         )
-        elements = _l("no match", "match this", "match that", "no match")
+        elements = make_text_spans("no match", "match this", "match that", "no match")
 
         # Act
         result = splitter(elements)
@@ -72,18 +75,18 @@ class TestMakeTextSegmentWhileSplitter(unittest.TestCase):
     def test_start_is_matching_argument(self):
         # Arrange
         def start_condition(elements, index):
-            return elements[index].contents == "match this"
+            return elements[index].children[0].contents == "match this"
 
         def while_condition(elements, index):
-            return elements[index].contents.startswith("match")
+            return elements[index].children[0].contents.startswith("match")
 
-        splitter = make_while_splitter_for_text_segments(
+        splitter = make_while_splitter_for_text_span_nodes(
             start_condition,
             while_condition,
         )
         elements = [
             Node(type="some_node", children=[]),
-            *_l("match this", "match that", "no match"),
+            *make_text_spans("match this", "match that", "no match"),
         ]
 
         # Act
@@ -95,13 +98,13 @@ class TestMakeTextSegmentWhileSplitter(unittest.TestCase):
     def test_not_interrupted_by_inline_node(self):
         # Arrange
         def probe(elements, index):
-            return elements[index].contents.startswith("match")
+            return elements[index].children[0].contents.startswith("match")
 
-        splitter = make_while_splitter_for_text_segments(probe, probe)
+        splitter = make_while_splitter_for_text_span_nodes(probe, probe)
         elements = [
-            *_l("match this"),
+            *make_text_spans("match this"),
             Node(type="page_separator", children=[]),
-            *_l("match this too", "but not this"),
+            *make_text_spans("match this too", "but not this"),
         ]
 
         # Act
@@ -111,25 +114,29 @@ class TestMakeTextSegmentWhileSplitter(unittest.TestCase):
         assert result == ([], elements[0:3], elements[3:])
 
 
-class TestTextSegmentGroupSplitter(unittest.TestCase):
+class TestGroupTextSpanNodesSplitter(unittest.TestCase):
 
     def test_single_text_segment(self):
         # Arrange
         elements = [
             Node(type="node1", children=[]),
-            *_l("line1", "line2", "line3"),
+            Node(type="text_span", children=_l("line1")),
+            Node(type="text_span", children=_l("line2", "line3")),
             Node(type="node2", children=[]),
         ]
 
         # Act
-        result = group_text_segments_splitter(elements)
+        result = group_text_span_nodes_splitter(elements)
 
         # Assert
         assert result == (
             [
                 Node(type="node1", children=[]),
             ],
-            _l("line1", "line2", "line3"),
+            [
+                Node(type="text_span", children=_l("line1")),
+                Node(type="text_span", children=_l("line2", "line3")),
+            ],
             [
                 Node(type="node2", children=[]),
             ],
@@ -142,7 +149,7 @@ class TestMakeTextSegmentProbeFromPattern(unittest.TestCase):
         # Arrange
         pattern = PatternProxy(r"^match")
         probe = make_probe_from_pattern_proxy(pattern)
-        lines = _l("match this")
+        lines = make_text_spans("match this")
 
         # Act
         result = probe(lines, 0)
@@ -154,7 +161,7 @@ class TestMakeTextSegmentProbeFromPattern(unittest.TestCase):
         # Arrange
         pattern = PatternProxy(r"^match")
         probe = make_probe_from_pattern_proxy(pattern)
-        lines = _l("no match here")
+        lines = make_text_spans("no match here")
 
         # Act
         result = probe(lines, 0)
@@ -163,25 +170,113 @@ class TestMakeTextSegmentProbeFromPattern(unittest.TestCase):
         assert result is False
 
 
-class TestPickTextSegments(unittest.TestCase):
+class TestPickTextSpanNode(unittest.TestCase):
 
     def test_simple(self):
         # Arrange
         elements = [
-            *_l("text1"),
+            Node(type="text_span", children=_l("bla1")),
             Node(type="some_node", children=[]),
-            *_l("text2", "text3"),
+            *_l("bla2"),
+            Node(type="text_span", children=_l("blo4", "bla5")),
         ]
 
-        def probe(elements, index):
-            return elements[index].contents.startswith("text")
+        def probe_first_child_starts_with_bla(elements, index):
+            return elements[index].children[0].contents.startswith("bla")
 
         # Act
-        text_segments_probe = pick_text_segment(probe)
+        text_span_node_probe = pick_text_span_node(probe_first_child_starts_with_bla)
 
         # Assert
-        assert text_segments_probe(elements, 0) is True
-        # If pick_text_segment not used, this should raise an error
-        assert text_segments_probe(elements, 1) is False
-        assert text_segments_probe(elements, 2) is True
-        assert text_segments_probe(elements, 3) is True
+        assert text_span_node_probe(elements, 0) is True  # text_span node with "bla1"
+        assert text_span_node_probe(elements, 1) is False  # some_node
+        assert text_span_node_probe(elements, 2) is False  # some TextSegment
+        assert text_span_node_probe(elements, 3) is False  # text_span node with "blo4"
+
+
+class TestGetString(unittest.TestCase):
+
+    def test_text_segment(self):
+        # Arrange
+        text_segment = _l("This is a test")[0]
+
+        # Act
+        result = get_string(text_segment)
+
+        # Assert
+        assert result == "This is a test"
+
+    def test_node_with_text_segments(self):
+        # Arrange
+        node = Node(type="some_node", children=_l("This is", " a test"))
+
+        # Act
+        result = get_string(node)
+
+        # Assert
+        assert result == "This is a test"
+
+    def test_node_with_text_spans(self):
+        # Arrange
+        node = Node(
+            type="some_node",
+            children=[
+                *_l("This is"),
+                Node(type="text_span", children=_l(" a test")),
+            ],
+        )
+
+        # Act
+        result = get_string(node)
+
+        # Assert
+        assert result == "This is a test"
+
+    def test_node_with_non_text_child(self):
+        # Arrange
+        node = Node(
+            type="some_node",
+            children=[
+                *_l("This is"),
+                Node(type="non_text", children=[]),
+                *_l(" a test"),
+            ],
+        )
+
+        # Assert
+        with self.assertRaises(ValueError):
+            get_string(node)
+
+
+class TestCombineTextSpans(unittest.TestCase):
+
+    def test_combine_list_text_spans_and_text_segments(self):
+        # Arrange
+        elements = [
+            Node(
+                type="text_span",
+                children=[
+                    TextSegment("This is", start=(1, 2, 3), end=(4, 5, 6)),
+                ],
+            ),
+            Node(
+                type="text_span",
+                children=[
+                    TextSegment(" a test", start=(7, 8, 9), end=(10, 11, 12)),
+                    TextSegment(" with multiple lines.", start=(13, 14, 15), end=(16, 17, 18)),
+                ],
+            ),
+        ]
+
+        # Act
+        result = combine_text_spans(elements)
+
+        # Assert
+        assert result == Node(
+            type="text_span",
+            children=[
+                TextSegment("This is", start=(1, 2, 3), end=(4, 5, 6)),
+                TextSegment(" a test", start=(7, 8, 9), end=(10, 11, 12)),
+                TextSegment(" with multiple lines.", start=(13, 14, 15), end=(16, 17, 18)),
+            ],
+        )

--- a/arretify/step_segmentation/document_elements.py
+++ b/arretify/step_segmentation/document_elements.py
@@ -44,9 +44,9 @@ from .core import (
     Node,
     NodeOrText,
     is_node,
-    assert_single_text_segment,
-    make_while_splitter_for_text_segments,
+    make_while_splitter_for_text_span_nodes,
     make_probe_from_pattern_proxy,
+    get_string,
 )
 
 
@@ -88,7 +88,7 @@ def parse_tables_of_contents(
     return map_splitted_elements(
         split_elements(
             elements,
-            make_while_splitter_for_text_segments(
+            make_while_splitter_for_text_span_nodes(
                 _is_table_of_contents,
                 _table_of_contents_while_condition,
             ),
@@ -112,7 +112,7 @@ def _table_of_contents_while_condition(elements: List[NodeOrText], index: int) -
     # between text segments.
     next_elements = elements[index : index + 3]
     if any(
-        isinstance(next_elements[i], TextSegment) and _is_table_of_contents(next_elements, i)
+        is_node(next_elements[i], type_in=["text_span"]) and _is_table_of_contents(next_elements, i)
         for i in range(len(next_elements))
     ):
         return True
@@ -125,14 +125,14 @@ def parse_page_footers(
     return map_splitted_elements(
         split_elements(
             elements,
-            make_while_splitter_for_text_segments(_is_page_footer, _is_page_footer),
+            make_while_splitter_for_text_span_nodes(_is_page_footer, _is_page_footer),
         ),
-        lambda pile: Node(type="page_footer", children=pile),
+        lambda children: Node(type="page_footer", children=children),
     )
 
 
 @iter_func_to_list
-def add_page_separators(
+def initialize_document_structure(
     elements: List[NodeOrText],
 ) -> Iterator[NodeOrText]:
     current_page = -1
@@ -143,7 +143,11 @@ def add_page_separators(
             and cast(TextSegment, elements[index]).start[0] != current_page,
         )
         if page_lines:
-            yield from page_lines
+            for line in page_lines:
+                yield Node(
+                    type="text_span",
+                    children=[line],
+                )
         if elements:
             assert isinstance(elements[0], TextSegment)
             current_page = elements[0].start[0]
@@ -160,12 +164,12 @@ def render_table_of_contents(
 ) -> Tag:
     page_elements: List[PageElementOrString] = []
     for element in node.children:
-        if isinstance(element, TextSegment):
-            page_elements.append(element.contents)
+        if is_node(element, type_in=["text_span"]):
+            page_elements.append(get_string(element))
         elif is_node(element, type_in=["page_separator"]):
             page_elements.append(render_page_separator(soup, element))
         else:
-            raise ValueError(f"Unexpected element type in table of contents: {element.type}")
+            raise ValueError(f"Unexpected element in table of contents: {element}")
     return make_data_tag(
         soup,
         TABLE_OF_CONTENTS_SCHEMA,
@@ -177,11 +181,10 @@ def render_page_footer(
     soup: BeautifulSoup,
     node: Node,
 ) -> Tag:
-    text_segment = assert_single_text_segment(node)
     return make_data_tag(
         soup,
         PAGE_FOOTER_SCHEMA,
-        contents=wrap_in_tag(soup, [text_segment.contents], "div"),
+        contents=wrap_in_tag(soup, [get_string(node)], "div"),
     )
 
 

--- a/arretify/step_segmentation/document_elements_test.py
+++ b/arretify/step_segmentation/document_elements_test.py
@@ -18,12 +18,19 @@
 #
 import unittest
 
+from bs4 import BeautifulSoup
+
 from .core import Node
-from .document_elements import add_page_separators, parse_tables_of_contents
-from .testing import _l, assert_elements_equal
+from .document_elements import (
+    initialize_document_structure,
+    parse_tables_of_contents,
+    render_table_of_contents,
+)
+from .testing import _l, assert_elements_equal, make_text_spans
+from arretify.utils.testing import normalized_html_str
 
 
-class TestAddPageSeparators(unittest.TestCase):
+class TestInitializeDocumentStructure(unittest.TestCase):
 
     def test_page_separators_inserted(self):
         # Arrange
@@ -45,18 +52,18 @@ class TestAddPageSeparators(unittest.TestCase):
         )
 
         # Act
-        result = list(add_page_separators(lines))
+        result = list(initialize_document_structure(lines))
 
         # Assert
         assert_elements_equal(
             result,
             [
                 Node(type="page_separator", data=dict(page_index=0), children=[]),
-                *_l("Line 1", "Line 2", "Line 3"),
+                *make_text_spans("Line 1", "Line 2", "Line 3"),
                 Node(type="page_separator", data=dict(page_index=1), children=[]),
-                *_l("Line 4", "Line 5"),
+                *make_text_spans("Line 4", "Line 5"),
                 Node(type="page_separator", data=dict(page_index=2), children=[]),
-                *_l("Line 6"),
+                *make_text_spans("Line 6"),
             ],
         )
 
@@ -65,7 +72,9 @@ class TestParseTablesOfContents(unittest.TestCase):
 
     def test_parse_tables_of_contents(self):
         # Arrange
-        lines = _l("Line 1", "Sommaire", "bla ..... page 1", "blo ..... page 2", "Line 2")
+        lines = make_text_spans(
+            "Line 1", "Sommaire", "bla ..... page 1", "blo ..... page 2", "Line 2"
+        )
 
         # Act
         elements = list(parse_tables_of_contents(lines))
@@ -74,16 +83,47 @@ class TestParseTablesOfContents(unittest.TestCase):
         assert_elements_equal(
             elements,
             [
-                *_l("Line 1"),
+                *make_text_spans("Line 1"),
                 Node(
                     type="table_of_contents",
                     data=dict(),
-                    children=_l(
+                    children=make_text_spans(
                         "Sommaire",
                         "bla ..... page 1",
                         "blo ..... page 2",
                     ),
                 ),
-                *_l("Line 2"),
+                *make_text_spans("Line 2"),
             ],
+        )
+
+
+class TestRenderTableOfContents(unittest.TestCase):
+
+    def setUp(self):
+        self.soup = BeautifulSoup("", "html.parser")
+
+    def test_simple_render(self):
+        # Arrange
+        node = Node(
+            type="table_of_contents",
+            children=[
+                Node(type="text_span", children=_l("Sommaire")),
+                Node(type="text_span", children=_l("bla ..... page 1")),
+                Node(type="text_span", children=_l("blo ..... page 2")),
+            ],
+        )
+
+        # Act
+        rendered = render_table_of_contents(self.soup, node)
+
+        # Assert
+        assert normalized_html_str(str(rendered)) == normalized_html_str(
+            """
+            <div class="arretify-table_of_contents">
+                <div>Sommaire</div>
+                <div>bla ..... page 1</div>
+                <div>blo ..... page 2</div>
+            </div>
+        """
         )

--- a/arretify/step_segmentation/header.py
+++ b/arretify/step_segmentation/header.py
@@ -50,12 +50,12 @@ from .core import (
     Node,
     NodeOrText,
     is_node,
-    make_while_splitter_for_text_segments,
-    make_single_line_splitter_for_text_segments,
-    assert_single_text_segment,
-    assert_all_text_segments,
-    group_text_segments_splitter,
+    make_while_splitter_for_text_span_nodes,
+    make_single_line_splitter_for_text_span_nodes,
+    group_text_span_nodes_splitter,
     make_probe_from_pattern_proxy,
+    get_string,
+    get_strings,
     INLINE_NODE_TYPES,
 )
 from .document_elements import (
@@ -63,7 +63,7 @@ from .document_elements import (
     render_page_separator,
     render_table_of_contents,
 )
-from .basic_elements import parse_lists, render_image, render_list
+from .basic_elements import parse_lists, render_image, render_list, render_text_span
 
 
 EMBLEMS_LIST = [
@@ -204,9 +204,9 @@ VISA_MOTIFS_PROBES: Dict[str, Probe[NodeOrText]] = dict(
 )
 
 
-def _is_nothing_else_than(name: str, t: NodeOrText) -> bool:
-    return isinstance(t, TextSegment) and not any(
-        bool(HEADER_ELEMENTS_PATTERNS[other_name].match(t.contents))
+def _is_nothing_else_than(name: str, element: NodeOrText) -> bool:
+    return is_node(element, type_in=["text_span"]) and not any(
+        bool(HEADER_ELEMENTS_PATTERNS[other_name].match(get_string(element)))
         for other_name in HEADER_ELEMENTS_PATTERNS
         if other_name != name
     )
@@ -249,13 +249,13 @@ def _parse_header_element(
     return map_splitted_elements(
         split_elements(
             elements,
-            make_while_splitter_for_text_segments(
+            make_while_splitter_for_text_span_nodes(
                 HEADER_ELEMENTS_PROBES[node_type], HEADER_ELEMENTS_PROBES[node_type]
             ),
         ),
-        lambda text_segments: Node(
+        lambda children: Node(
             type=node_type,
-            children=text_segments,
+            children=children,
         ),
     )
 
@@ -272,14 +272,14 @@ def _parse_header_element_fuzzy(
     return map_splitted_elements(
         split_elements(
             elements,
-            make_while_splitter_for_text_segments(
+            make_while_splitter_for_text_span_nodes(
                 HEADER_ELEMENTS_FUZZY_PROBES[node_type],
                 lambda elements, index: _is_nothing_else_than(node_type, elements[index]),
             ),
         ),
-        lambda text_segments: Node(
+        lambda children: Node(
             type=node_type,
-            children=text_segments,
+            children=children,
         ),
     )
 
@@ -367,11 +367,11 @@ def _parse_visa_and_motif_elements_pass1(
     elements = map_splitted_elements(
         split_elements(
             elements,
-            make_single_line_splitter_for_text_segments(VISA_MOTIFS_PROBES[node_type]),
+            make_single_line_splitter_for_text_span_nodes(VISA_MOTIFS_PROBES[node_type]),
         ),
-        lambda text_segments: Node(
+        lambda children: Node(
             type=node_type,
-            children=text_segments,
+            children=children,
         ),
     )
 
@@ -384,19 +384,13 @@ def _parse_visa_and_motif_elements_pass1(
     for element in elements:
         is_list_of_visas_or_motifs = False
         if is_node(element, type_in=["list"]):
-            text_segments: List[NodeOrText] = [
-                child for child in element.children if isinstance(child, TextSegment)
-            ]
-            is_list_of_visas_or_motifs = len(text_segments) > 0 and VISA_MOTIFS_PROBES[node_type](
-                text_segments, 0
-            )
+            assert len(element.children) > 0, "List node should not be empty"
+            is_list_of_visas_or_motifs = VISA_MOTIFS_PROBES[node_type](element.children, 0)
 
         if is_list_of_visas_or_motifs:
             assert is_node(element)
             for list_item_element in element.children:
-                if is_node(list_item_element):
-                    yield list_item_element
-                elif isinstance(list_item_element, TextSegment):
+                if is_node(list_item_element, type_in=["text_span"]):
                     yield Node(
                         type=node_type,
                         children=[list_item_element],
@@ -428,11 +422,13 @@ def _parse_visa_and_motif_elements_pass2(
     if not elements:
         return
     first_node = elements.pop(0)
-    assert is_node(first_node, type_in=[node_type])
-
-    first_node_match = VISA_MOTIFS_PATTERNS[node_type].match(
-        assert_single_text_segment(first_node).contents
+    assert (
+        is_node(first_node, type_in=[node_type])
+        and len(first_node.children) > 0
+        and is_node(first_node.children[0])
     )
+
+    first_node_match = VISA_MOTIFS_PATTERNS[node_type].match(get_string(first_node))
     # 1. Variant "simple" :
     #   Vu que blabla
     #   Vu que bloblo
@@ -445,10 +441,11 @@ def _parse_visa_and_motif_elements_pass2(
                 len(elements) >= 3
                 and is_node(elements[0], type_in=[node_type])
                 and is_node(elements[1], type_in=["page_separator"])
-                and isinstance(elements[2], TextSegment)
+                and is_node(elements[2], type_in=["text_span"])
+                and is_node(elements[0].children[0])
                 and is_continuing_sentence(
-                    assert_single_text_segment(elements[0]).contents,
-                    elements[2].contents,
+                    get_string(elements[0].children[0]),
+                    get_string(elements[2]),
                 )
             ):
                 elements[0].children.extend([elements[1], elements[2]])
@@ -467,19 +464,23 @@ def _parse_visa_and_motif_elements_pass2(
         yield from first_node.children
         while elements:
             element = elements[0]
-            if is_node(element, type_in=INLINE_NODE_TYPES) or isinstance(element, TextSegment):
+            # We're a bit lenient here and accept a few unassigned_line nodes,
+            # as random text sometimes interferes with the parsing.
+            if is_node(element, type_in=INLINE_NODE_TYPES) or is_node(
+                element, type_in=["text_span"]
+            ):
                 yield elements.pop(0)
 
             elif is_node(element, type_in=["list"]):
                 elements.pop(0)
                 for list_item_element in element.children:
-                    if is_node(list_item_element):
-                        yield list_item_element
-                    elif isinstance(list_item_element, TextSegment):
+                    if is_node(list_item_element, type_in=["text_span"]):
                         yield Node(
                             type=node_type,
                             children=[list_item_element],
                         )
+                    else:
+                        yield list_item_element
             else:
                 break
         yield from elements
@@ -499,11 +500,12 @@ def _parse_visa_and_motif_elements_pass2(
             if is_node(element, type_in=["list", *INLINE_NODE_TYPES]):
                 yield elements.pop(0)
 
-            elif isinstance(element, TextSegment):
+            elif is_node(element, type_in=["text_span"]):
                 yield Node(
                     type=node_type,
-                    children=[elements.pop(0)],
+                    children=[element],
                 )
+                elements.pop(0)
             else:
                 break
         yield from elements
@@ -568,6 +570,14 @@ def render_header(
             content.append(render_image(soup, element))
         elif is_node(element, type_in=["list"]):
             content.append(render_list(soup, element))
+        elif is_node(element, type_in=["text_span"]):
+            content.append(
+                make_new_tag(
+                    soup,
+                    "div",
+                    contents=render_text_span(soup, element),
+                )
+            )
 
         elif is_node(element):
             raise ValueError(f"Unexpected node {element.type} in content")
@@ -586,10 +596,10 @@ def render_header_element(
 
     for splitted_element in split_elements(
         node.children,
-        group_text_segments_splitter,
+        group_text_span_nodes_splitter,
     ):
         if isinstance(splitted_element, SplitMatch):
-            strings = [t.contents for t in splitted_element.value]
+            strings = get_strings(splitted_element.value)
             if pattern is not None:
                 elements.extend(join_split_pile_with_pattern(strings, pattern))
             else:
@@ -615,14 +625,14 @@ def render_visa_motif(
     assert is_node(node, type_in=["visa", "motif"])
     elements: List[PageElementOrString] = []
     for element in node.children:
-        if is_node(element, type_in=["list"]):
+        if is_node(element, type_in=["text_span"]):
+            elements.append(get_string(element))
+        elif is_node(element, type_in=["list"]):
             elements.append(render_list(soup, element))
         elif is_node(element, type_in=["page_separator"]):
             elements.append(render_page_separator(soup, element))
-        elif isinstance(element, TextSegment):
-            elements.append(element.contents)
         else:
-            raise ValueError(f"Unexpected node {element.type} in visa/motif contents")
+            raise ValueError(f"Unexpected element {element} in visa/motif")
     return make_data_tag(
         soup,
         HEADER_ELEMENTS_SCHEMAS[node.type],
@@ -634,9 +644,9 @@ def rendre_arrete_title(
     soup: BeautifulSoup,
     node: Node,
 ) -> Tag:
-    elements: List[PageElementOrString] = [
-        " ".join([element.contents for element in assert_all_text_segments(node)])
-    ]
+    elements: List[PageElementOrString] = [" ".join(get_strings(node.children))]
+    # TODO : Parsing date should be done in a node and not on the fly
+    # like this.
     elements = map_splitted_elements(
         split_elements(
             elements,

--- a/arretify/step_segmentation/header_test.py
+++ b/arretify/step_segmentation/header_test.py
@@ -23,11 +23,13 @@ from bs4 import BeautifulSoup
 from arretify.utils.testing import normalized_html_str
 from .header import (
     parse_visa_and_motif_elements,
-    render_header_element,
     _parse_header_element,
     _parse_header_element_fuzzy,
+    render_header_element,
+    render_visa_motif,
+    rendre_arrete_title,
 )
-from .testing import assert_elements_equal, _l
+from .testing import assert_elements_equal, make_text_spans
 from .core import Node
 
 
@@ -35,7 +37,7 @@ class TestParseVisaAndMotifs(unittest.TestCase):
 
     def test_variant_simple(self):
         # Arrange
-        elements = _l(
+        elements = make_text_spans(
             (
                 "Vu le code de l'environnement, et notamment ses titres "
                 "1er et 4 des parties réglementaires et législatives du livre V ;"
@@ -55,7 +57,7 @@ class TestParseVisaAndMotifs(unittest.TestCase):
             [
                 Node(
                     type="visa",
-                    children=_l(
+                    children=make_text_spans(
                         (
                             "Vu le code de l'environnement, et notamment ses titres "
                             "1er et 4 des parties réglementaires et législatives du livre V ;"
@@ -64,7 +66,7 @@ class TestParseVisaAndMotifs(unittest.TestCase):
                 ),
                 Node(
                     type="visa",
-                    children=_l(
+                    children=make_text_spans(
                         (
                             "Vu la nomenclature des installations classées codifiée à l'annexe "
                             "de l'article R511-9 du code de l'environnement ;"
@@ -77,9 +79,9 @@ class TestParseVisaAndMotifs(unittest.TestCase):
     def test_variant_simple_interrupted_by_random_text(self):
         # Arrange
         elements = [
-            *_l("Vu bla"),
-            *_l("Ceci est du texte aléatoire qui n'est pas un visa."),
-            *_l("Vu blo"),
+            *make_text_spans("Vu bla"),
+            *make_text_spans("Ceci est du texte aléatoire qui n'est pas un visa."),
+            *make_text_spans("Vu blo"),
         ]
 
         # Act
@@ -91,12 +93,12 @@ class TestParseVisaAndMotifs(unittest.TestCase):
             [
                 Node(
                     type="visa",
-                    children=_l("Vu bla"),
+                    children=make_text_spans("Vu bla"),
                 ),
-                *_l("Ceci est du texte aléatoire qui n'est pas un visa."),
+                *make_text_spans("Ceci est du texte aléatoire qui n'est pas un visa."),
                 Node(
                     type="visa",
-                    children=_l("Vu blo"),
+                    children=make_text_spans("Vu blo"),
                 ),
             ],
         )
@@ -106,7 +108,7 @@ class TestParseVisaAndMotifs(unittest.TestCase):
         elements = [
             Node(
                 type="list",
-                children=_l(
+                children=make_text_spans(
                     "- Considérant que blabla ;",
                     "- Considérant que bloblo ;",
                 ),
@@ -122,13 +124,13 @@ class TestParseVisaAndMotifs(unittest.TestCase):
             [
                 Node(
                     type="motif",
-                    children=_l(
+                    children=make_text_spans(
                         "- Considérant que blabla ;",
                     ),
                 ),
                 Node(
                     type="motif",
-                    children=_l(
+                    children=make_text_spans(
                         "- Considérant que bloblo ;",
                     ),
                 ),
@@ -138,12 +140,12 @@ class TestParseVisaAndMotifs(unittest.TestCase):
     def test_variant_simple_page_separator_interrupting_sentence(self):
         # Arrange
         elements = [
-            *_l("Vu le code de l'environnement, et notamment ses titres 1er et 4"),
+            *make_text_spans("Vu le code de l'environnement, et notamment ses titres 1er et 4"),
             Node(
                 type="page_separator",
                 children=[],
             ),
-            *_l("des parties réglementaires et législatives du livre V ;"),
+            *make_text_spans("des parties réglementaires et législatives du livre V ;"),
         ]
 
         # Act
@@ -156,12 +158,14 @@ class TestParseVisaAndMotifs(unittest.TestCase):
                 Node(
                     type="visa",
                     children=[
-                        *_l("Vu le code de l'environnement, et notamment ses titres 1er et 4"),
+                        *make_text_spans(
+                            "Vu le code de l'environnement, et notamment ses titres 1er et 4"
+                        ),
                         Node(
                             type="page_separator",
                             children=[],
                         ),
-                        *_l("des parties réglementaires et législatives du livre V ;"),
+                        *make_text_spans("des parties réglementaires et législatives du livre V ;"),
                     ],
                 ),
             ],
@@ -169,7 +173,7 @@ class TestParseVisaAndMotifs(unittest.TestCase):
 
     def test_variant_implicit_list(self):
         # Arrange
-        elements = _l(
+        elements = make_text_spans(
             "CONSIDÉRANT : ",
             "que blabla ;",
             "que bloblo ;",
@@ -183,18 +187,18 @@ class TestParseVisaAndMotifs(unittest.TestCase):
         assert_elements_equal(
             result,
             [
-                *_l("CONSIDÉRANT : "),
+                *make_text_spans("CONSIDÉRANT : "),
                 Node(
                     type="motif",
-                    children=_l("que blabla ;"),
+                    children=make_text_spans("que blabla ;"),
                 ),
                 Node(
                     type="motif",
-                    children=_l("que bloblo ;"),
+                    children=make_text_spans("que bloblo ;"),
                 ),
                 Node(
                     type="motif",
-                    children=_l("qu'en application de blibli ;"),
+                    children=make_text_spans("qu'en application de blibli ;"),
                 ),
             ],
         )
@@ -202,7 +206,7 @@ class TestParseVisaAndMotifs(unittest.TestCase):
     def test_variant_implicit_list_interrupted_by_page_footer(self):
         # Arrange
         elements = [
-            *_l(
+            *make_text_spans(
                 "Vu : ",
                 (
                     "le code de l'environnement, et notamment ses titres "
@@ -211,9 +215,9 @@ class TestParseVisaAndMotifs(unittest.TestCase):
             ),
             Node(
                 type="page_footer",
-                children=_l("page 1"),
+                children=make_text_spans("page 1"),
             ),
-            *_l(
+            *make_text_spans(
                 (
                     "la nomenclature des installations classées codifiée à l'annexe "
                     "de l'article R511-9 du code de l'environnement ;"
@@ -228,23 +232,23 @@ class TestParseVisaAndMotifs(unittest.TestCase):
         assert_elements_equal(
             result,
             [
-                *_l(
+                *make_text_spans(
                     "Vu : ",
                 ),
                 Node(
                     type="visa",
-                    children=_l(
+                    children=make_text_spans(
                         "le code de l'environnement, et notamment ses titres "
                         "1er et 4 des parties réglementaires et législatives du livre V ;"
                     ),
                 ),
                 Node(
                     type="page_footer",
-                    children=_l("page 1"),
+                    children=make_text_spans("page 1"),
                 ),
                 Node(
                     type="visa",
-                    children=_l(
+                    children=make_text_spans(
                         "la nomenclature des installations classées codifiée à l'annexe "
                         "de l'article R511-9 du code de l'environnement ;"
                     ),
@@ -255,10 +259,10 @@ class TestParseVisaAndMotifs(unittest.TestCase):
     def test_variant_explicit_list(self):
         # Arrange
         elements = [
-            *_l("Vu : "),
+            *make_text_spans("Vu : "),
             Node(
                 type="list",
-                children=_l(
+                children=make_text_spans(
                     "- le code de l'environnement ;",
                     "- la nomenclature des installations classées ;",
                 ),
@@ -272,14 +276,14 @@ class TestParseVisaAndMotifs(unittest.TestCase):
         assert_elements_equal(
             result,
             [
-                *_l("Vu : "),
+                *make_text_spans("Vu : "),
                 Node(
                     type="visa",
-                    children=_l("- le code de l'environnement ;"),
+                    children=make_text_spans("- le code de l'environnement ;"),
                 ),
                 Node(
                     type="visa",
-                    children=_l("- la nomenclature des installations classées ;"),
+                    children=make_text_spans("- la nomenclature des installations classées ;"),
                 ),
             ],
         )
@@ -287,17 +291,17 @@ class TestParseVisaAndMotifs(unittest.TestCase):
     def test_variant_explicit_list_interrupted(self):
         # Arrange
         elements = [
-            *_l("Vu : "),
+            *make_text_spans("Vu : "),
             Node(
                 type="list",
-                children=_l(
+                children=make_text_spans(
                     "- le code de l'environnement ;",
                 ),
             ),
-            *_l("Ceci est du texte aléatoire qui n'est pas un visa."),
+            *make_text_spans("Ceci est du texte aléatoire qui n'est pas un visa."),
             Node(
                 type="list",
-                children=_l(
+                children=make_text_spans(
                     "- la nomenclature des installations classées ;",
                 ),
             ),
@@ -310,15 +314,15 @@ class TestParseVisaAndMotifs(unittest.TestCase):
         assert_elements_equal(
             result,
             [
-                *_l("Vu : "),
+                *make_text_spans("Vu : "),
                 Node(
                     type="visa",
-                    children=_l("- le code de l'environnement ;"),
+                    children=make_text_spans("- le code de l'environnement ;"),
                 ),
-                *_l("Ceci est du texte aléatoire qui n'est pas un visa."),
+                *make_text_spans("Ceci est du texte aléatoire qui n'est pas un visa."),
                 Node(
                     type="visa",
-                    children=_l("- la nomenclature des installations classées ;"),
+                    children=make_text_spans("- la nomenclature des installations classées ;"),
                 ),
             ],
         )
@@ -326,10 +330,10 @@ class TestParseVisaAndMotifs(unittest.TestCase):
     def test_variant_explicit_list_vu_inside_list_element(self):
         # Arrange
         elements = [
-            *_l("Vu : "),
+            *make_text_spans("Vu : "),
             Node(
                 type="list",
-                children=_l(
+                children=make_text_spans(
                     "- le code de l'environnement ;",
                     "- la nomenclature des installations classées ;",
                     "- vu la demande déposée par la société XYZ ;",
@@ -344,18 +348,18 @@ class TestParseVisaAndMotifs(unittest.TestCase):
         assert_elements_equal(
             result,
             [
-                *_l("Vu : "),
+                *make_text_spans("Vu : "),
                 Node(
                     type="visa",
-                    children=_l("- le code de l'environnement ;"),
+                    children=make_text_spans("- le code de l'environnement ;"),
                 ),
                 Node(
                     type="visa",
-                    children=_l("- la nomenclature des installations classées ;"),
+                    children=make_text_spans("- la nomenclature des installations classées ;"),
                 ),
                 Node(
                     type="visa",
-                    children=_l("- vu la demande déposée par la société XYZ ;"),
+                    children=make_text_spans("- vu la demande déposée par la société XYZ ;"),
                 ),
             ],
         )
@@ -363,7 +367,7 @@ class TestParseVisaAndMotifs(unittest.TestCase):
     def test_variant_simple_with_list_inside_and_interrupted_by_age_separator(self):
         # Arrange
         elements = [
-            *_l(
+            *make_text_spans(
                 "Considérant que la demande de modification sollicitée "
                 "le 19 juillet 2021 porte sur :"
             ),
@@ -373,7 +377,7 @@ class TestParseVisaAndMotifs(unittest.TestCase):
             ),
             Node(
                 type="list",
-                children=_l(
+                children=make_text_spans(
                     "- la modification de l'installation de stockage de déchets non dangereux ;",
                     "- la mise en conformité avec les exigences réglementaires ;",
                 ),
@@ -390,7 +394,7 @@ class TestParseVisaAndMotifs(unittest.TestCase):
                 Node(
                     type="motif",
                     children=[
-                        *_l(
+                        *make_text_spans(
                             "Considérant que la demande de modification sollicitée "
                             "le 19 juillet 2021 porte sur :"
                         ),
@@ -400,7 +404,7 @@ class TestParseVisaAndMotifs(unittest.TestCase):
                         ),
                         Node(
                             type="list",
-                            children=_l(
+                            children=make_text_spans(
                                 "- la modification de l'installation de stockage de déchets "
                                 "non dangereux ;",
                                 "- la mise en conformité avec les exigences réglementaires ;",
@@ -421,7 +425,7 @@ class TestRenderHeaderElement(unittest.TestCase):
         # Arrange
         node = Node(
             type="emblem",
-            children=_l(
+            children=make_text_spans(
                 "liberté égalité fraternité",
             ),
         )
@@ -445,7 +449,7 @@ class TestParseHeaderElement(unittest.TestCase):
 
     def test_parse_header_element(self):
         # Arrange
-        elements = _l(
+        elements = make_text_spans(
             "liberte",
             "égalité",
             "fraternité",
@@ -460,7 +464,7 @@ class TestParseHeaderElement(unittest.TestCase):
             [
                 Node(
                     type="emblem",
-                    children=_l(
+                    children=make_text_spans(
                         "liberte",
                         "égalité",
                         "fraternité",
@@ -471,7 +475,7 @@ class TestParseHeaderElement(unittest.TestCase):
 
     def test_parse_header_element_fuzzy(self):
         # Arrange
-        elements = _l(
+        elements = make_text_spans(
             "prefecture de la région",
             "basée à Naboo",
             # Arrete title : should not be included in the entity
@@ -487,13 +491,73 @@ class TestParseHeaderElement(unittest.TestCase):
             [
                 Node(
                     type="entity",
-                    children=_l(
+                    children=make_text_spans(
                         "prefecture de la région",
                         "basée à Naboo",
                     ),
                 ),
-                *_l(
+                *make_text_spans(
                     "Arrêté du 1er janvier 2020",
                 ),
             ],
+        )
+
+
+class TestRenderVisaMotif(unittest.TestCase):
+
+    def setUp(self):
+        self.soup = BeautifulSoup("", features="html.parser")
+
+    def test_render_simple(self):
+        # Arrange
+        node = Node(
+            type="visa",
+            children=make_text_spans(
+                "Vu le code de l'environnement, et notamment ses titres "
+                "1er et 4 des parties réglementaires et législatives du livre V ;",
+            ),
+        )
+
+        # Act
+        rendered = render_visa_motif(self.soup, node)
+
+        # Assert
+        assert normalized_html_str(str(rendered)) == normalized_html_str(
+            """
+            <div class="arretify-visa">
+                Vu le code de l'environnement, et notamment ses titres
+                1er et 4 des parties réglementaires et législatives du livre V ;
+            </div>
+            """
+        )
+
+
+class TestRenderArreteTitle(unittest.TestCase):
+
+    def setUp(self):
+        self.soup = BeautifulSoup("", features="html.parser")
+
+    def test_render_arrete_title(self):
+        # Arrange
+        node = Node(
+            type="arrete_title",
+            children=make_text_spans(
+                "Arrêté du 1er janvier 2020",
+            ),
+        )
+
+        # Act
+        rendered = rendre_arrete_title(self.soup, node)
+
+        # Assert
+        assert normalized_html_str(str(rendered)) == normalized_html_str(
+            """
+            <div class="arretify-arrete_title">
+                <h1>Arrêté du
+                    <time class="arretify-date" datetime="2020-01-01">
+                        1er janvier 2020
+                    </time>
+                </h1>
+            </div>
+            """
         )

--- a/arretify/step_segmentation/parse_arrete.py
+++ b/arretify/step_segmentation/parse_arrete.py
@@ -16,16 +16,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import List, cast
+from typing import List, Iterator
 
-from arretify.types import DocumentContext, SectionType, TextSegment
+from bs4 import BeautifulSoup
+
+from arretify.types import SectionType, PageElementOrString
 from arretify.html_schemas import (
     HEADER_SCHEMA,
     MAIN_SCHEMA,
     APPENDIX_SCHEMA,
 )
 from arretify.utils.html_create import make_data_tag
-from arretify.utils.functional import chain_functions
+from arretify.utils.functional import chain_functions, iter_func_to_list
 from arretify.utils.split_merge import (
     split_before_match,
 )
@@ -33,26 +35,33 @@ from .header import parse_header, render_header
 from .titles_detection import TITLE_NODE, parse_title_info
 from .content import parse_content, render_content
 from .core import (
+    Node,
     NodeOrText,
-    make_probe_from_pattern,
-    pick_text_segment,
+    make_probe_from_pattern_proxy,
+    pick_text_span_node,
+    is_node,
+    get_string,
 )
 from .basic_elements import parse_images
-from .document_elements import parse_page_footers, parse_tables_of_contents, add_page_separators
+from .document_elements import (
+    parse_page_footers,
+    parse_tables_of_contents,
+    initialize_document_structure,
+)
 
 
-_is_title = make_probe_from_pattern(
+_is_title = make_probe_from_pattern_proxy(
     TITLE_NODE.pattern,
 )
-_is_title_text_segment = pick_text_segment(_is_title)
+_is_title_line = pick_text_span_node(_is_title)
 
 
 def _is_appendix(elements: List[NodeOrText], index: int) -> bool:
     element = elements[index]
-    assert isinstance(element, TextSegment)
-    if _is_title(elements, index):
+    assert is_node(element)
+    if _is_title_line(elements, index):
         # Parse title info
-        title_info = parse_title_info(element.contents)
+        title_info = parse_title_info(get_string(element))
         new_section_type = title_info.section_type
 
         # Appendix is considered as a different part of the document
@@ -61,45 +70,53 @@ def _is_appendix(elements: List[NodeOrText], index: int) -> bool:
     return False
 
 
-_is_appendix_text_segment = pick_text_segment(_is_appendix)
+_is_appendix_text_segment = pick_text_span_node(_is_appendix)
 
 
-def parse_arrete(document_context: DocumentContext) -> DocumentContext:
-    body = document_context.soup.body
-    assert body
-
-    lines = document_context.lines
-    assert lines
-
-    elements: List[NodeOrText] = cast(List[NodeOrText], lines)
+@iter_func_to_list
+def parse_arrete(elements: List[NodeOrText]) -> Iterator[NodeOrText]:
     # Add basic document elements
     elements = chain_functions(
         elements,
         # Image strings can be very long, and table of contents pattern look
         # at the end of the sentence.
         # So, we make sure we parse images before table of contents.
-        [add_page_separators, parse_images, parse_page_footers, parse_tables_of_contents],
+        [initialize_document_structure, parse_images, parse_page_footers, parse_tables_of_contents],
     )
 
     # Header
-    pile, elements = split_before_match(elements, _is_title_text_segment)
-    header = make_data_tag(document_context.soup, HEADER_SCHEMA)
-    body.append(header)
-    rendered_header = render_header(document_context.soup, list(parse_header(pile)))
-    header.extend(list(rendered_header.children))
+    pile, elements = split_before_match(elements, _is_title_line)
+    yield Node(
+        type="header",
+        children=parse_header(pile),
+    )
 
     # Main content
     pile, elements = split_before_match(elements, _is_appendix_text_segment)
-    main_content = make_data_tag(document_context.soup, MAIN_SCHEMA)
-    body.append(main_content)
-    rendered_content = render_content(document_context.soup, list(parse_content(pile)))
-    main_content.extend(list(rendered_content.children))
+    yield Node(
+        type="main",
+        children=parse_content(pile),
+    )
 
     # Appendix
     if elements:
-        appendix = make_data_tag(document_context.soup, APPENDIX_SCHEMA)
-        body.append(appendix)
-        rendered_appendix = render_content(document_context.soup, list(parse_content(elements)))
-        appendix.extend(list(rendered_appendix.children))
+        yield Node(
+            type="appendix",
+            children=parse_content(elements),
+        )
 
-    return document_context
+
+@iter_func_to_list
+def render_arrete(soup: BeautifulSoup, elements: List[NodeOrText]) -> Iterator[PageElementOrString]:
+    body = soup.body
+    assert body
+
+    for element in elements:
+        if is_node(element, type_in=["header"]):
+            yield make_data_tag(soup, HEADER_SCHEMA, contents=render_header(soup, element.children))
+        elif is_node(element, type_in=["main"]):
+            yield make_data_tag(soup, MAIN_SCHEMA, contents=render_content(soup, element.children))
+        elif is_node(element, type_in=["appendix"]):
+            yield make_data_tag(
+                soup, APPENDIX_SCHEMA, contents=render_content(soup, element.children)
+            )

--- a/arretify/step_segmentation/parse_arrete_test.py
+++ b/arretify/step_segmentation/parse_arrete_test.py
@@ -1,0 +1,93 @@
+#
+# Copyright (c) 2025 Direction générale de la prévention des risques (DGPR).
+#
+# This file is part of Arrêtify.
+# See https://github.com/mte-dgpr/arretify for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import unittest
+
+from .core import Node
+from .parse_arrete import parse_arrete
+from .testing import make_text_spans, _l, assert_elements_equal
+
+
+class TestParseArrete(unittest.TestCase):
+
+    def test_simple(self):
+        # Arrange
+        lines = _l(
+            "Arrêté n° 123",
+            "Article 1 : Disposition",
+            "Bla bla bla ...",
+            "Annexe 1 : Détails",
+            "Bla bla bla ...",
+        )
+
+        # Act
+        elements = parse_arrete(lines)
+
+        # Assert
+        assert_elements_equal(
+            elements,
+            [
+                Node(
+                    type="header",
+                    children=[
+                        Node(
+                            type="page_separator",
+                            children=[],
+                        ),
+                        Node(type="arrete_title", children=make_text_spans("Arrêté n° 123")),
+                    ],
+                ),
+                Node(
+                    type="main",
+                    children=[
+                        Node(
+                            type="section",
+                            children=[
+                                Node(
+                                    type="section_title",
+                                    children=make_text_spans("Article 1 : Disposition"),
+                                ),
+                                Node(
+                                    type="alinea",
+                                    children=make_text_spans("Bla bla bla ..."),
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+                Node(
+                    type="appendix",
+                    children=[
+                        Node(
+                            type="section",
+                            children=[
+                                Node(
+                                    type="section_title",
+                                    children=make_text_spans("Annexe 1 : Détails"),
+                                ),
+                                Node(
+                                    type="alinea",
+                                    children=make_text_spans("Bla bla bla ..."),
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+            ignore_data_if_omitted=True,
+        )

--- a/arretify/step_segmentation/testing.py
+++ b/arretify/step_segmentation/testing.py
@@ -20,7 +20,7 @@ from typing import List
 
 from arretify.parsing_utils.source_mapping import initialize_page
 from arretify.types import TextSegment
-from .core import NodeOrText, is_node
+from .core import NodeOrText, is_node, Node
 
 
 def assert_elements_equal(
@@ -60,3 +60,10 @@ def _line_column_to_zero(text_segment: TextSegment) -> TextSegment:
 
 def _l(*raw_lines: str, page_index: int = 0) -> List[TextSegment]:
     return initialize_page("\n".join(raw_lines), page_index)
+
+
+def make_text_spans(*raw_lines: str, page_index: int = 0) -> List[Node]:
+    return [
+        Node(type="text_span", children=[text_segment])
+        for text_segment in initialize_page("\n".join(raw_lines), page_index)
+    ]

--- a/arretify/types.py
+++ b/arretify/types.py
@@ -39,9 +39,9 @@ PageLineColumn = Tuple[int, int, int]
 
 @dataclass(frozen=True)
 class TextSegment:
+    contents: str
     start: PageLineColumn
     end: PageLineColumn
-    contents: str
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/arretify/utils/markdown_parsing.py
+++ b/arretify/utils/markdown_parsing.py
@@ -24,7 +24,6 @@ from bs4 import BeautifulSoup, Tag
 
 from arretify.errors import ErrorCodes
 from arretify.utils.html import (
-    PageElementOrString,
     render_str_list_attribute,
 )
 from arretify.utils.html_create import make_data_tag
@@ -63,7 +62,7 @@ IMAGE_PATTERN = PatternProxy(r"!\[[^\[\]]+\]\([^()]+\)")
 """Detect if the line starts with an image."""
 
 
-def is_table_description(line: str, pile: List[PageElementOrString]) -> bool:
+def is_table_description(line: str, pile: List[str]) -> bool:
     # Sentence starts with any number of * between parentheses or without parentheses
     match = TABLE_DESCRIPTION_PATTERN.match(line)
     if match:


### PR DESCRIPTION
PR préparatoire pour le parsing des adresses, qui nous permettra d'enlever des feux positifs pour les titres d'articles.

L'idée ici est dans la segmentation d'avoir tous les TextSegment dans un node de type "text_span", comme ça on pourra insérer d'autres types de nodes inline (e.g. `address`), car pour l'instant avec juste des TextSegments ça n'est pas possible.