### PR TITLE
T479 spec tag hierarchy [part2]

### DIFF
--- a/arretify/parsing_utils/dates.py
+++ b/arretify/parsing_utils/dates.py
@@ -24,7 +24,8 @@ from arretify.semantic_tag_specs import DateSpec
 from arretify.types import ProtectedSoup, ProtectedTag
 from arretify.utils.dates import DATE_STR_LENGTH, parse_year_str, render_date_str
 from arretify.utils.html import set_attribute
-from arretify.utils.html_semantic import make_semantic_tag, update_data
+from arretify.utils.html_create import make_semantic_tag
+from arretify.utils.html_semantic import update_data
 from arretify.regex_utils import (
     regex_tree,
     join_with_or,
@@ -214,5 +215,4 @@ def render_date_regex_tree_match(
         contents=iter_regex_tree_match_page_elements_or_strings(regex_tree_match),
         data=date_data,
     )
-    set_attribute(date_container, "datetime", date_str)
-    return date_container
+    return set_attribute(date_container, "datetime", date_str)

--- a/arretify/semantic_tag_specs.py
+++ b/arretify/semantic_tag_specs.py
@@ -29,6 +29,7 @@ from arretify.utils.html_semantic import (
     SemanticTagSpec,
     SemanticTagData,
     Bool,
+    Contents,
     StrList,
     create_semantic_tag_spec_no_data,
     enum_serializer,
@@ -36,31 +37,14 @@ from arretify.utils.html_semantic import (
 from arretify.types import OperationType, SectionType
 
 
-# -------------------- Parts -------------------- #
-
-
-HeaderSpec = create_semantic_tag_spec_no_data(
-    spec_name="header",
-    tag_name="header",
-)
-
-MainSpec = create_semantic_tag_spec_no_data(
-    spec_name="main",
-    tag_name="main",
-)
-
-AppendixSpec = create_semantic_tag_spec_no_data(
-    spec_name="appendix",
-    tag_name="footer",
-)
-
-
-# -------------------- Document -------------------- #
+# -------------------- Page structure -------------------- #
 
 
 PageFooterSpec = create_semantic_tag_spec_no_data(
     spec_name="page_footer",
     tag_name="div",
+    allowed_contents=(Contents.Tag("div"),),
+    is_allowed_anywhere=True,
 )
 
 
@@ -72,128 +56,41 @@ PageSeparatorSpec: SemanticTagSpec[PageSeparatorData] = SemanticTagSpec(
     spec_name="page_separator",
     tag_name="a",
     data_model=PageSeparatorData,
+    is_allowed_anywhere=True,
 )
+
+
+# -------------------- Generic elements -------------------- #
+
+
+DateSpec = create_semantic_tag_spec_no_data(
+    spec_name="date",
+    tag_name="time",
+    allowed_contents=(Contents.Str(),),
+    is_allowed_anywhere=True,
+)
+
+
+AddressSpec = create_semantic_tag_spec_no_data(
+    spec_name="address",
+    tag_name="address",
+    allowed_contents=(Contents.Str(),),
+    is_allowed_anywhere=True,
+)
+
 
 TableOfContentsSpec = create_semantic_tag_spec_no_data(
     spec_name="table_of_contents",
     tag_name="div",
+    allowed_contents=(Contents.Tag("div"),),
 )
 
 
-# -------------------- Header -------------------- #
-
-
-EmblemSpec = create_semantic_tag_spec_no_data(
-    spec_name="emblem",
-    tag_name="div",
-)
-
-EntitySpec = create_semantic_tag_spec_no_data(
-    spec_name="entity",
-    tag_name="div",
-)
-
-IdentificationSpec = create_semantic_tag_spec_no_data(
-    spec_name="identification",
-    tag_name="div",
-)
-
-ArreteSpec = create_semantic_tag_spec_no_data(
-    spec_name="arrete_title",
-    tag_name="div",
-)
-
-HonorarySpec = create_semantic_tag_spec_no_data(
-    spec_name="honorary",
-    tag_name="div",
-)
-
-VisaSpec = create_semantic_tag_spec_no_data(
-    spec_name="visa",
-    tag_name="div",
-)
-
-MotifSpec = create_semantic_tag_spec_no_data(
-    spec_name="motifs",
-    tag_name="div",
-)
-
-SupplementaryMotifInfoSpec = create_semantic_tag_spec_no_data(
-    spec_name="supplementary_motif_info",
-    tag_name="div",
-)
-
-
-# -------------------- Main and appendix -------------------- #
-
-
-class SectionData(SemanticTagData):
-    title: str | None
-    number: str
-    type: str
-
-
-SectionSpec: SemanticTagSpec[SectionData] = SemanticTagSpec(
-    spec_name="section",
-    tag_name="section",
-    data_model=SectionData,
-)
-
-SectionTitle1Spec = create_semantic_tag_spec_no_data(
-    spec_name="section_title",
-    tag_name="h2",
-)
-
-SectionTitle2Spec = create_semantic_tag_spec_no_data(
-    spec_name="section_title",
-    tag_name="h3",
-)
-
-SectionTitle3Spec = create_semantic_tag_spec_no_data(
-    spec_name="section_title",
-    tag_name="h4",
-)
-
-SectionTitle4Spec = create_semantic_tag_spec_no_data(
-    spec_name="section_title",
-    tag_name="h5",
-)
-
-SectionTitle5Spec = create_semantic_tag_spec_no_data(
-    spec_name="section_title",
-    tag_name="h6",
-)
-
-SectionTitle6Spec = create_semantic_tag_spec_no_data(
-    spec_name="section_title",
-    tag_name="h7",
-)
-
-SectionTitle7Spec = create_semantic_tag_spec_no_data(
-    spec_name="section_title",
-    tag_name="h8",
-)
-
-
-SectionTitleSpecs = [
-    SectionTitle1Spec,
-    SectionTitle2Spec,
-    SectionTitle3Spec,
-    SectionTitle4Spec,
-    SectionTitle5Spec,
-    SectionTitle6Spec,
-    SectionTitle7Spec,
-]
-
-
-class AlineaData(SemanticTagData):
-    number: int
-
-
-AlineaSpec: SemanticTagSpec[AlineaData] = SemanticTagSpec(
-    spec_name="alinea",
-    tag_name="div",
-    data_model=AlineaData,
+ErrorSpec = create_semantic_tag_spec_no_data(
+    spec_name="error",
+    tag_name="span",
+    allowed_contents=(Contents.Str(),),
+    is_allowed_anywhere=True,
 )
 
 
@@ -241,13 +138,15 @@ DocumentReferenceSpec: SemanticTagSpec[DocumentReferenceData] = SemanticTagSpec(
     spec_name="document_reference",
     tag_name="a",
     data_model=DocumentReferenceData,
+    allowed_contents=(Contents.Str(),),
+    is_allowed_anywhere=True,
 )
 
 
 class SectionReferenceData(SemanticTagData):
-    type: Annotated[SectionType, enum_serializer] | None = None  # TODO:BETTER-TESTS
+    type: Annotated[SectionType, enum_serializer] | None = None
     parent_reference: str | None = None
-    start_num: str | None = None  # TODO:BETTER-TESTS
+    start_num: str | None = None
     start_id: str | None = None
     end_id: str | None = None
     end_num: str | None = None
@@ -257,6 +156,8 @@ SectionReferenceSpec: SemanticTagSpec[SectionReferenceData] = SemanticTagSpec(
     spec_name="section_reference",
     tag_name="a",
     data_model=SectionReferenceData,
+    allowed_contents=(Contents.Str(),),
+    is_allowed_anywhere=True,
 )
 
 
@@ -276,28 +177,188 @@ OperationSpec: SemanticTagSpec[OperationData] = SemanticTagSpec(
     spec_name="operation",
     tag_name="span",
     data_model=OperationData,
+    allowed_contents=(Contents.Str(),),
+    is_allowed_anywhere=True,
+)
+
+# -------------------- Header -------------------- #
+
+
+EmblemSpec = create_semantic_tag_spec_no_data(
+    spec_name="emblem",
+    tag_name="div",
+    allowed_contents=(Contents.Tag("div"),),
+)
+
+EntitySpec = create_semantic_tag_spec_no_data(
+    spec_name="entity",
+    tag_name="div",
+    allowed_contents=(Contents.Tag("div"),),
+)
+
+IdentificationSpec = create_semantic_tag_spec_no_data(
+    spec_name="identification",
+    tag_name="div",
+    allowed_contents=(Contents.Tag("div"),),
+)
+
+ArreteTitleSpec = create_semantic_tag_spec_no_data(
+    spec_name="arrete_title",
+    tag_name="div",
+    allowed_contents=(Contents.Tag("h1"),),
+)
+
+HonorarySpec = create_semantic_tag_spec_no_data(
+    spec_name="honorary",
+    tag_name="div",
+    allowed_contents=(Contents.Tag("div"),),
+)
+
+VisaSpec = create_semantic_tag_spec_no_data(
+    spec_name="visa",
+    tag_name="div",
+    allowed_contents=(
+        Contents.Str(),
+        Contents.Tag("ul"),
+    ),
+)
+
+MotifSpec = create_semantic_tag_spec_no_data(
+    spec_name="motifs",
+    tag_name="div",
+    allowed_contents=(
+        Contents.Str(),
+        Contents.Tag("ul"),
+    ),
+)
+
+SupplementaryMotifInfoSpec = create_semantic_tag_spec_no_data(
+    spec_name="supplementary_motif_info",
+    tag_name="div",
+    allowed_contents=(Contents.Tag("div"),),
+)
+
+HeaderSpec = create_semantic_tag_spec_no_data(
+    spec_name="header",
+    tag_name="header",
+    allowed_contents=(
+        Contents.SemanticTag(EmblemSpec.spec_name),
+        Contents.SemanticTag(EntitySpec.spec_name),
+        Contents.SemanticTag(IdentificationSpec.spec_name),
+        Contents.SemanticTag(ArreteTitleSpec.spec_name),
+        Contents.SemanticTag(HonorarySpec.spec_name),
+        Contents.SemanticTag(VisaSpec.spec_name),
+        Contents.SemanticTag(MotifSpec.spec_name),
+        Contents.SemanticTag(SupplementaryMotifInfoSpec.spec_name),
+        Contents.SemanticTag(TableOfContentsSpec.spec_name),
+        # For lines in the header that havent been recognized as a particular element
+        Contents.Tag("div"),
+        Contents.Tag("img"),
+    ),
 )
 
 
-# -------------------- Other -------------------- #
+# -------------------- Main + appendix structure -------------------- #
 
 
-DateSpec = create_semantic_tag_spec_no_data(
-    spec_name="date",
-    tag_name="time",
+SectionTitle1Spec = create_semantic_tag_spec_no_data(
+    spec_name="section_title", tag_name="h2", allowed_contents=(Contents.Str(),)
+)
+
+SectionTitle2Spec = create_semantic_tag_spec_no_data(
+    spec_name="section_title", tag_name="h3", allowed_contents=(Contents.Str(),)
+)
+
+SectionTitle3Spec = create_semantic_tag_spec_no_data(
+    spec_name="section_title", tag_name="h4", allowed_contents=(Contents.Str(),)
+)
+
+SectionTitle4Spec = create_semantic_tag_spec_no_data(
+    spec_name="section_title", tag_name="h5", allowed_contents=(Contents.Str(),)
+)
+
+SectionTitle5Spec = create_semantic_tag_spec_no_data(
+    spec_name="section_title", tag_name="h6", allowed_contents=(Contents.Str(),)
+)
+
+SectionTitle6Spec = create_semantic_tag_spec_no_data(
+    spec_name="section_title", tag_name="h7", allowed_contents=(Contents.Str(),)
+)
+
+SectionTitle7Spec = create_semantic_tag_spec_no_data(
+    spec_name="section_title", tag_name="h8", allowed_contents=(Contents.Str(),)
 )
 
 
-AddressSpec = create_semantic_tag_spec_no_data(
-    spec_name="address",
-    tag_name="address",
+SectionTitleSpecs = [
+    SectionTitle1Spec,
+    SectionTitle2Spec,
+    SectionTitle3Spec,
+    SectionTitle4Spec,
+    SectionTitle5Spec,
+    SectionTitle6Spec,
+    SectionTitle7Spec,
+]
+
+
+class AlineaData(SemanticTagData):
+    number: int
+
+
+AlineaSpec: SemanticTagSpec[AlineaData] = SemanticTagSpec(
+    spec_name="alinea",
+    tag_name="div",
+    data_model=AlineaData,
+    allowed_contents=(
+        Contents.Str(),
+        Contents.Tag("ul"),
+        Contents.Tag("table"),
+        Contents.Tag("blockquote"),
+        Contents.Tag("q"),
+        Contents.Tag("img"),
+    ),
 )
 
 
-# -------------------- Errors -------------------- #
+class SectionData(SemanticTagData):
+    title: str | None
+    number: str
+    type: str
 
 
-ErrorSpec = create_semantic_tag_spec_no_data(
-    spec_name="error",
-    tag_name="span",
+SectionSpec: SemanticTagSpec[SectionData] = SemanticTagSpec(
+    spec_name="section",
+    tag_name="section",
+    data_model=SectionData,
+    allowed_contents=(
+        Contents.SemanticTag("section_title"),
+        Contents.SemanticTag(AlineaSpec.spec_name),
+        Contents.SemanticTag("section"),
+        # Table of contents can be included in appendix sections
+        Contents.SemanticTag(TableOfContentsSpec.spec_name),
+    ),
+)
+
+MainSpec = create_semantic_tag_spec_no_data(
+    spec_name="main",
+    tag_name="main",
+    allowed_contents=(Contents.SemanticTag(SectionSpec.spec_name),),
+)
+
+AppendixSpec = create_semantic_tag_spec_no_data(
+    spec_name="appendix",
+    tag_name="footer",
+    allowed_contents=(Contents.SemanticTag(SectionSpec.spec_name),),
+)
+
+
+# -------------------- Arrete -------------------- #
+ArreteSpec = create_semantic_tag_spec_no_data(
+    spec_name="arrete",
+    tag_name="body",
+    allowed_contents=(
+        Contents.SemanticTag(HeaderSpec.spec_name),
+        Contents.SemanticTag(MainSpec.spec_name),
+        Contents.SemanticTag(AppendixSpec.spec_name),
+    ),
 )

--- a/arretify/step_consolidation/operations_detection.py
+++ b/arretify/step_consolidation/operations_detection.py
@@ -25,8 +25,7 @@ from arretify.regex_utils import (
     filter_regex_tree_match_children,
     join_with_or,
 )
-from arretify.utils.html_semantic import make_semantic_tag
-from arretify.utils.html_create import make_new_tag
+from arretify.utils.html_create import make_new_tag, make_semantic_tag
 from arretify.utils.strings import merge_strings
 from arretify.utils.html_split_merge import make_regex_tree_splitter
 from arretify.utils.split_merge import split_elements, map_splitted_elements

--- a/arretify/step_references_detection/arretes_detection.py
+++ b/arretify/step_references_detection/arretes_detection.py
@@ -27,6 +27,7 @@ from typing import (
 )
 
 from arretify.types import DocumentContext, ProtectedSoup, ProtectedTag
+from arretify.utils.html_create import make_semantic_tag
 from arretify.utils.split_merge import (
     split_elements,
     map_splitted_elements,
@@ -36,7 +37,6 @@ from arretify.utils.html import (
     ProtectedTagOrStr,
     is_tag,
 )
-from arretify.utils.html_semantic import make_semantic_tag
 from arretify.utils.html_split_merge import make_regex_tree_splitter
 from arretify.semantic_tag_specs import (
     DocumentReferenceData,

--- a/arretify/step_references_detection/circulaires_detection.py
+++ b/arretify/step_references_detection/circulaires_detection.py
@@ -33,9 +33,9 @@ from arretify.semantic_tag_specs import (
     DocumentReferenceSpec,
 )
 from arretify.utils.html import is_tag
+from arretify.utils.html_create import make_semantic_tag
 from arretify.utils.html_split_merge import make_regex_tree_splitter
 from arretify.utils.split_merge import split_elements, map_splitted_elements
-from arretify.utils.html_semantic import make_semantic_tag
 from arretify.types import (
     DocumentType,
 )

--- a/arretify/step_references_detection/codes_detection.py
+++ b/arretify/step_references_detection/codes_detection.py
@@ -33,9 +33,9 @@ from arretify.semantic_tag_specs import (
     DocumentReferenceData,
     DocumentReferenceSpec,
 )
+from arretify.utils.html_create import make_semantic_tag
 from arretify.utils.html_split_merge import make_regex_tree_splitter
 from arretify.utils.split_merge import split_elements, map_splitted_elements
-from arretify.utils.html_semantic import make_semantic_tag
 
 
 # TODO: Makes parsing very slow, because compiles into a big OR regex.

--- a/arretify/step_references_detection/decrets_detection.py
+++ b/arretify/step_references_detection/decrets_detection.py
@@ -33,9 +33,9 @@ from arretify.semantic_tag_specs import (
     DocumentReferenceSpec,
 )
 from arretify.utils.html import is_tag
+from arretify.utils.html_create import make_semantic_tag
 from arretify.utils.html_split_merge import make_regex_tree_splitter
 from arretify.utils.split_merge import split_elements, map_splitted_elements
-from arretify.utils.html_semantic import make_semantic_tag
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/arretify/step_references_detection/eu_acts_detection.py
+++ b/arretify/step_references_detection/eu_acts_detection.py
@@ -35,7 +35,7 @@ from arretify.semantic_tag_specs import (
     DocumentReferenceData,
     DocumentReferenceSpec,
 )
-from arretify.utils.html_semantic import make_semantic_tag
+from arretify.utils.html_create import make_semantic_tag
 from arretify.utils.html_split_merge import make_regex_tree_splitter
 from arretify.utils.split_merge import split_elements, map_splitted_elements
 from arretify.law_data.eurlex_constants import (

--- a/arretify/step_references_detection/sections_detection.py
+++ b/arretify/step_references_detection/sections_detection.py
@@ -35,7 +35,7 @@ from arretify.semantic_tag_specs import (
     SectionReferenceSpec,
 )
 from arretify.utils.html import make_group_id, set_group_id
-from arretify.utils.html_semantic import make_semantic_tag
+from arretify.utils.html_create import make_semantic_tag
 from arretify.utils.html_split_merge import make_regex_tree_splitter
 from arretify.utils.split_merge import (
     split_elements,

--- a/arretify/step_references_detection/self_detection.py
+++ b/arretify/step_references_detection/self_detection.py
@@ -28,9 +28,9 @@ from arretify.semantic_tag_specs import (
     DocumentReferenceData,
     DocumentReferenceSpec,
 )
+from arretify.utils.html_create import make_semantic_tag
 from arretify.utils.html_split_merge import make_regex_tree_splitter
 from arretify.utils.split_merge import split_elements, map_splitted_elements
-from arretify.utils.html_semantic import make_semantic_tag
 
 
 SELF_NODE = regex_tree.Group(

--- a/arretify/step_segmentation/__step__.py
+++ b/arretify/step_segmentation/__step__.py
@@ -16,8 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from arretify.semantic_tag_specs import ArreteSpec
 from arretify.types import DocumentContext
-from arretify.utils.html_create import replace_children
+from arretify.utils.html_create import replace_children, upgrade_to_semantic_tag
 from .parse_arrete import parse_arrete, render_arrete
 
 
@@ -25,12 +26,12 @@ def step_segmentation(document_context: DocumentContext) -> DocumentContext:
     if not document_context.pages:
         raise ValueError("Parsing context does not contain any pages to segment")
 
-    body = document_context.protected_soup.body
-    assert body
-
     pages = document_context.pages
     assert pages
 
+    body = document_context.protected_soup.body
+    assert body
+    upgrade_to_semantic_tag(body, ArreteSpec)
     replace_children(
         body,
         render_arrete(

--- a/arretify/step_segmentation/basic_elements.py
+++ b/arretify/step_segmentation/basic_elements.py
@@ -25,19 +25,19 @@ from arretify.step_segmentation.semantic_tag_specs import (
     TableDescriptionSegmentationSpec,
     TableSegmentationSpec,
     BlockquoteSegmentationSpec,
-    ImageSegmentationSpec,
     TextSpanSegmentationSpec,
 )
 from arretify.types import DocumentContext, ProtectedTagOrStr, ProtectedTag
 from arretify.utils.functional import iter_func_to_list, chain_functions
+from arretify.utils.html import is_tag
 from arretify.utils.html_semantic import (
     SemanticTagData,
     get_semantic_tag_data,
     is_semantic_tag,
-    make_semantic_tag,
 )
 from arretify.utils.html_create import (
     make_new_tag,
+    make_semantic_tag,
     replace_children,
 )
 from arretify.utils.markdown_parsing import (
@@ -70,6 +70,7 @@ from arretify.utils.split_merge import (
     Probe,
     RawSplit,
     Splitter,
+    split_and_map_elements,
     split_elements,
     map_splitted_elements,
     flat_map_splitted_elements,
@@ -93,7 +94,6 @@ from .core import (
     pick_if_transparent_tag_followed_by_match,
     make_pattern_splitter,
 )
-from .document_elements import render_table_of_contents, render_page_footer
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -522,22 +522,11 @@ def parse_images(
     context: DocumentContext,
     elements: Sequence[ProtectedTagOrStr],
 ) -> list[ProtectedTagOrStr]:
-    return map_splitted_elements(
-        split_elements(
-            elements,
-            make_single_line_splitter_for_text_spans(_is_image),
-        ),
-        lambda contents: make_semantic_tag(
-            context.protected_soup, ImageSegmentationSpec, contents=contents
-        ),
+    return split_and_map_elements(
+        elements,
+        make_single_line_splitter_for_text_spans(_is_image),
+        lambda contents: parse_markdown_image(get_string(contents[0])),
     )
-
-
-def render_image(
-    context: DocumentContext,
-    tag: ProtectedTag,
-) -> ProtectedTag:
-    return parse_markdown_image(get_string(tag))
 
 
 # -------------------- Addresses -------------------- #
@@ -662,17 +651,13 @@ def render_basic_elements(
         yield from render_table_description(context, tag)
     elif is_semantic_tag(tag, spec_in=[BlockquoteSegmentationSpec]):
         yield render_blockquote(context, tag)
-    elif is_semantic_tag(tag, spec_in=[TableOfContentsSpec]):
-        yield render_table_of_contents(context, tag)
-    elif is_semantic_tag(tag, spec_in=[PageFooterSpec]):
-        yield render_page_footer(context, tag)
-    elif is_semantic_tag(tag, spec_in=[PageSeparatorSpec]):
-        yield tag
-    elif is_semantic_tag(tag, spec_in=[ImageSegmentationSpec]):
-        yield render_image(context, tag)
-    elif is_semantic_tag(tag, spec_in=[ErrorSpec]):
+    elif is_semantic_tag(
+        tag, spec_in=[PageFooterSpec, PageSeparatorSpec, TableOfContentsSpec, ErrorSpec]
+    ):
         yield tag
     elif is_semantic_tag(tag, spec_in=[TextSpanSegmentationSpec]):
         yield from render_text_span(context, tag)
+    elif is_tag(tag, tag_name_in=["img"]):
+        yield tag
     else:
         raise ValueError(f"Unknown tag type '{tag.name}' in render_basic_elements.")

--- a/arretify/step_segmentation/basic_elements_test.py
+++ b/arretify/step_segmentation/basic_elements_test.py
@@ -29,13 +29,12 @@ from arretify.step_segmentation.semantic_tag_specs import (
     TableDescriptionSegmentationSpec,
     ListSegmentationSpec,
     BlockquoteSegmentationSpec,
-    ImageSegmentationSpec,
     TextSpanSegmentationData,
     TextSpanSegmentationSpec,
 )
+from arretify.utils.html_create import make_new_tag, make_semantic_tag
 from arretify.utils.html_semantic import (
     create_semantic_tag_spec_no_data,
-    make_semantic_tag,
 )
 
 from .basic_elements import (
@@ -686,10 +685,10 @@ class TestParseImage(BaseTestCase):
         assert_elements_equal(
             result,
             [
-                make_semantic_tag(
+                make_new_tag(
                     self.soup,
-                    ImageSegmentationSpec,
-                    contents=make_text_spans(self.soup, "![Image description](image_url.jpg)"),
+                    "img",
+                    attrs=dict(src="image_url.jpg", alt="Image description"),
                 ),
                 *make_text_spans(self.soup, "END"),
             ],

--- a/arretify/step_segmentation/content.py
+++ b/arretify/step_segmentation/content.py
@@ -22,20 +22,19 @@ import logging
 from bs4 import Tag
 
 from arretify.types import DocumentContext, ProtectedTag, SectionType, ProtectedTagOrStr
+from arretify.utils.html_create import make_semantic_tag
 from arretify.utils.html_semantic import (
     SemanticTagData,
+    SemanticTagSpec,
     get_semantic_tag_data,
     get_semantic_tag_spec,
     is_semantic_tag,
-    make_semantic_tag,
     set_semantic_tag_data,
-)
-from arretify.utils.html_create import (
-    replace_children,
 )
 from arretify.utils.functional import iter_func_to_list, chain_functions
 from arretify.utils.split import split_at_first_verb
 from arretify.step_segmentation.semantic_tag_specs import (
+    AlineaSegmentationSpec,
     SectionTitleSegmentationData,
     SectionTitleSegmentationSpec,
     TableDescriptionSegmentationSpec,
@@ -45,12 +44,12 @@ from arretify.step_segmentation.semantic_tag_specs import (
 )
 from arretify.semantic_tag_specs import (
     AlineaData,
+    AlineaSpec,
     PageFooterSpec,
     PageSeparatorSpec,
     SectionData,
     SectionSpec,
     SectionTitleSpecs,
-    AlineaSpec,
     TableOfContentsSpec,
 )
 from arretify.errors import ErrorCodes
@@ -79,10 +78,6 @@ from .core import (
     make_single_line_splitter_for_text_spans,
     make_probe_from_pattern_proxy,
     get_string,
-)
-from .document_elements import (
-    render_page_footer,
-    render_table_of_contents,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -121,18 +116,24 @@ def parse_content(
     return elements
 
 
-@iter_func_to_list
 def render_content(
     context: DocumentContext,
+    spec: SemanticTagSpec,
     elements: Sequence[ProtectedTagOrStr],
-) -> Iterator[ProtectedTag]:
+) -> ProtectedTag:
+    contents: list[ProtectedTagOrStr] = []
     for tag in elements:
         if is_semantic_tag(tag, spec_in=[SectionSegmentationSpec]):
-            yield render_section(context, tag)
+            contents.append(render_section(context, tag))
         elif is_semantic_tag(tag, spec_in=[TableOfContentsSpec]):
-            yield render_table_of_contents(context, tag)
+            contents.append(tag)
         else:
             raise ValueError(f"Unexpected element {tag}")
+    return make_semantic_tag(
+        context.protected_soup,
+        spec,
+        contents=contents,
+    )
 
 
 def parse_section_titles(
@@ -438,13 +439,11 @@ def render_section(
             contents.append(render_section_title(context, element))
         elif is_semantic_tag(element, spec_in=[SectionSegmentationSpec]):
             contents.append(render_section(context, element))
-        elif is_semantic_tag(element, spec_in=[AlineaSpec]):
+        elif is_semantic_tag(element, spec_in=[AlineaSegmentationSpec]):
             contents.append(render_alinea(context, element))
-        elif is_semantic_tag(element, spec_in=[PageFooterSpec]):
-            contents.append(render_page_footer(context, element))
-        elif is_semantic_tag(element, spec_in=[TableOfContentsSpec]):
-            contents.append(render_table_of_contents(context, element))
-        elif is_semantic_tag(element, spec_in=[PageSeparatorSpec]):
+        elif is_semantic_tag(
+            element, spec_in=[PageFooterSpec, PageSeparatorSpec, TableOfContentsSpec]
+        ):
             contents.append(element)
         elif isinstance(element, str):
             contents.append(element)
@@ -520,7 +519,7 @@ def parse_alineas(
             alinea_children = [element]
         yield make_semantic_tag(
             context.protected_soup,
-            AlineaSpec,
+            AlineaSegmentationSpec,
             contents=alinea_children,
             data=AlineaData(
                 number=alinea_count,
@@ -549,4 +548,9 @@ def render_alinea(
             contents.extend(render_inline_quotes(context, element))
         else:
             raise ValueError(f"Unexpected tag {element} in alinea contents")
-    return replace_children(tag, contents)
+    return make_semantic_tag(
+        context.protected_soup,
+        AlineaSpec,
+        data=get_semantic_tag_data(AlineaSegmentationSpec, tag),
+        contents=contents,
+    )

--- a/arretify/step_segmentation/content_test.py
+++ b/arretify/step_segmentation/content_test.py
@@ -22,11 +22,10 @@ from arretify.semantic_tag_specs import (
     AddressSpec,
     PageSeparatorData,
     PageSeparatorSpec,
-    AlineaSpec,
     AlineaData,
 )
+from arretify.utils.html_create import make_semantic_tag
 from arretify.utils.testing import create_document_context, normalized_html_str
-from arretify.utils.html_semantic import make_semantic_tag
 from .content import (
     parse_section_titles,
     parse_sections,
@@ -40,6 +39,7 @@ from .testing import (
     make_text_spans,
 )
 from .semantic_tag_specs import (
+    AlineaSegmentationSpec,
     SectionSegmentationSpec,
     SectionTitleSegmentationData,
     SectionTitleSegmentationSpec,
@@ -151,7 +151,7 @@ class TestParseSectionTitles(BaseTestCase):
                     make_semantic_tag(
                         self.soup,
                         AddressSpec,
-                        contents=make_text_spans(self.soup, "1 rue de l'avenir"),
+                        contents=["1 rue de l'avenir"],
                     )
                 ],
                 data=TextSpanSegmentationData(start=[0, 0, 0], end=[0, 0, 0]),
@@ -183,7 +183,7 @@ class TestParseSectionTitles(BaseTestCase):
                         make_semantic_tag(
                             self.soup,
                             AddressSpec,
-                            contents=make_text_spans(self.soup, "1 rue de l'avenir"),
+                            contents=["1 rue de l'avenir"],
                         )
                     ],
                     data=TextSpanSegmentationData(start=[0, 0, 0], end=[0, 0, 0]),
@@ -245,7 +245,7 @@ class TestParseSections(BaseTestCase):
             [
                 make_semantic_tag(
                     self.soup,
-                    AlineaSpec,
+                    AlineaSegmentationSpec,
                     contents=make_text_spans(self.soup, "bly bly bly"),
                     data=AlineaData(number="1"),
                 ),
@@ -275,7 +275,7 @@ class TestParseSections(BaseTestCase):
                                 ),
                                 make_semantic_tag(
                                     self.soup,
-                                    AlineaSpec,
+                                    AlineaSegmentationSpec,
                                     contents=make_text_spans(self.soup, "bla bla bla"),
                                     data=AlineaData(number="1"),
                                 ),
@@ -295,13 +295,13 @@ class TestParseSections(BaseTestCase):
                                 ),
                                 make_semantic_tag(
                                     self.soup,
-                                    AlineaSpec,
+                                    AlineaSegmentationSpec,
                                     contents=make_text_spans(self.soup, "blo blo blo"),
                                     data=AlineaData(number="1"),
                                 ),
                                 make_semantic_tag(
                                     self.soup,
-                                    AlineaSpec,
+                                    AlineaSegmentationSpec,
                                     contents=make_text_spans(self.soup, "bli bli bli"),
                                     data=AlineaData(number="2"),
                                 ),
@@ -323,13 +323,13 @@ class TestParseSections(BaseTestCase):
                         ),
                         make_semantic_tag(
                             self.soup,
-                            AlineaSpec,
+                            AlineaSegmentationSpec,
                             contents=make_text_spans(self.soup, "blu blu blu"),
                             data=AlineaData(number="1"),
                         ),
                         make_semantic_tag(
                             self.soup,
-                            AlineaSpec,
+                            AlineaSegmentationSpec,
                             contents=make_text_spans(self.soup, "ble ble ble"),
                             data=AlineaData(number="2"),
                         ),
@@ -346,17 +346,17 @@ class TestParseSections(BaseTestCase):
             make_semantic_tag(
                 self.soup,
                 SectionTitleSegmentationSpec,
-                contents=["1. Bla"],
+                contents=make_text_spans(self.soup, "1. Bla"),
                 data=SectionTitleSegmentationData(level=0),
             ),
-            "bla bla bla",
+            *make_text_spans(self.soup, "bla bla bla"),
             make_semantic_tag(
                 self.soup,
                 SectionTitleSegmentationSpec,
-                contents=["1.1. Blabla"],
+                contents=make_text_spans(self.soup, "1.1. Blabla"),
                 data=SectionTitleSegmentationData(level=1),
             ),
-            "bli bli bli",
+            *make_text_spans(self.soup, "bli bli bli"),
         ]
 
         # Act
@@ -373,13 +373,13 @@ class TestParseSections(BaseTestCase):
                         make_semantic_tag(
                             self.soup,
                             SectionTitleSegmentationSpec,
-                            contents=["1. Bla"],
+                            contents=make_text_spans(self.soup, "1. Bla"),
                             data=SectionTitleSegmentationData(level=0),
                         ),
                         make_semantic_tag(
                             self.soup,
-                            AlineaSpec,
-                            contents=["bla bla bla"],
+                            AlineaSegmentationSpec,
+                            contents=make_text_spans(self.soup, "bla bla bla"),
                             data=AlineaData(number="1"),
                         ),
                         make_semantic_tag(
@@ -389,13 +389,13 @@ class TestParseSections(BaseTestCase):
                                 make_semantic_tag(
                                     self.soup,
                                     SectionTitleSegmentationSpec,
-                                    contents=["1.1. Blabla"],
+                                    contents=make_text_spans(self.soup, "1.1. Blabla"),
                                     data=SectionTitleSegmentationData(level=1),
                                 ),
                                 make_semantic_tag(
                                     self.soup,
-                                    AlineaSpec,
-                                    contents=["bli bli bli"],
+                                    AlineaSegmentationSpec,
+                                    contents=make_text_spans(self.soup, "bli bli bli"),
                                     data=AlineaData(number="1"),
                                 ),
                             ],
@@ -413,13 +413,13 @@ class TestParseSections(BaseTestCase):
             make_semantic_tag(
                 self.soup,
                 SectionTitleSegmentationSpec,
-                contents=["1. Bla"],
+                contents=make_text_spans(self.soup, "1. Bla"),
                 data=SectionTitleSegmentationData(level=0),
             ),
             make_semantic_tag(
                 self.soup,
                 SectionTitleSegmentationSpec,
-                contents=["1.1.1. Blabla"],
+                contents=make_text_spans(self.soup, "1.1.1. Blabla"),
                 data=SectionTitleSegmentationData(level=2),
             ),
         ]
@@ -438,7 +438,7 @@ class TestParseSections(BaseTestCase):
                         make_semantic_tag(
                             self.soup,
                             SectionTitleSegmentationSpec,
-                            contents=["1. Bla"],
+                            contents=make_text_spans(self.soup, "1. Bla"),
                             data=SectionTitleSegmentationData(level=0),
                         ),
                         make_semantic_tag(
@@ -448,7 +448,7 @@ class TestParseSections(BaseTestCase):
                                 make_semantic_tag(
                                     self.soup,
                                     SectionTitleSegmentationSpec,
-                                    contents=["1.1.1. Blabla"],
+                                    contents=make_text_spans(self.soup, "1.1.1. Blabla"),
                                     data=SectionTitleSegmentationData(level=2),
                                 ),
                             ],
@@ -466,31 +466,31 @@ class TestParseSections(BaseTestCase):
             make_semantic_tag(
                 self.soup,
                 SectionTitleSegmentationSpec,
-                contents=["1.1. bla"],
+                contents=make_text_spans(self.soup, "1.1. bla"),
                 data=SectionTitleSegmentationData(level=1),
             ),
             make_semantic_tag(
                 self.soup,
                 SectionTitleSegmentationSpec,
-                contents=["1.1.1. bla"],
+                contents=make_text_spans(self.soup, "1.1.1. bla"),
                 data=SectionTitleSegmentationData(level=2),
             ),
             make_semantic_tag(
                 self.soup,
                 SectionTitleSegmentationSpec,
-                contents=["1.2. bla"],
+                contents=make_text_spans(self.soup, "1.2. bla"),
                 data=SectionTitleSegmentationData(level=1),
             ),
             make_semantic_tag(
                 self.soup,
                 SectionTitleSegmentationSpec,
-                contents=["2. bla"],
+                contents=make_text_spans(self.soup, "2. bla"),
                 data=SectionTitleSegmentationData(level=0),
             ),
             make_semantic_tag(
                 self.soup,
                 SectionTitleSegmentationSpec,
-                contents=["2.1. bla"],
+                contents=make_text_spans(self.soup, "2.1. bla"),
                 data=SectionTitleSegmentationData(level=1),
             ),
         ]
@@ -509,7 +509,7 @@ class TestParseSections(BaseTestCase):
                         make_semantic_tag(
                             self.soup,
                             SectionTitleSegmentationSpec,
-                            contents=["1.1. bla"],
+                            contents=make_text_spans(self.soup, "1.1. bla"),
                             data=SectionTitleSegmentationData(level=1),
                         ),
                         make_semantic_tag(
@@ -519,7 +519,7 @@ class TestParseSections(BaseTestCase):
                                 make_semantic_tag(
                                     self.soup,
                                     SectionTitleSegmentationSpec,
-                                    contents=["1.1.1. bla"],
+                                    contents=make_text_spans(self.soup, "1.1.1. bla"),
                                     data=SectionTitleSegmentationData(level=2),
                                 ),
                             ],
@@ -533,7 +533,7 @@ class TestParseSections(BaseTestCase):
                         make_semantic_tag(
                             self.soup,
                             SectionTitleSegmentationSpec,
-                            contents=["1.2. bla"],
+                            contents=make_text_spans(self.soup, "1.2. bla"),
                             data=SectionTitleSegmentationData(level=1),
                         ),
                     ],
@@ -545,7 +545,7 @@ class TestParseSections(BaseTestCase):
                         make_semantic_tag(
                             self.soup,
                             SectionTitleSegmentationSpec,
-                            contents=["2. bla"],
+                            contents=make_text_spans(self.soup, "2. bla"),
                             data=SectionTitleSegmentationData(level=0),
                         ),
                         make_semantic_tag(
@@ -555,7 +555,7 @@ class TestParseSections(BaseTestCase):
                                 make_semantic_tag(
                                     self.soup,
                                     SectionTitleSegmentationSpec,
-                                    contents=["2.1. bla"],
+                                    contents=make_text_spans(self.soup, "2.1. bla"),
                                     data=SectionTitleSegmentationData(level=1),
                                 ),
                             ],
@@ -587,7 +587,7 @@ class TestParseAlineas(BaseTestCase):
             [
                 make_semantic_tag(
                     self.soup,
-                    AlineaSpec,
+                    AlineaSegmentationSpec,
                     contents=[
                         make_semantic_tag(
                             self.soup,
@@ -618,7 +618,7 @@ class TestRenderAlinea(BaseTestCase):
         # Arrange
         alinea = make_semantic_tag(
             self.soup,
-            AlineaSpec,
+            AlineaSegmentationSpec,
             contents=make_text_spans(self.soup, "This is an alinea."),
             data=AlineaData(number="1"),
         )
@@ -657,7 +657,7 @@ class TestRenderSection(BaseTestCase):
                 ),
                 make_semantic_tag(
                     self.soup,
-                    AlineaSpec,
+                    AlineaSegmentationSpec,
                     contents=make_text_spans(self.soup, "Bla bla bla ..."),
                     data=AlineaData(number="1"),
                 ),

--- a/arretify/step_segmentation/core.py
+++ b/arretify/step_segmentation/core.py
@@ -31,11 +31,11 @@ from arretify.step_segmentation.semantic_tag_specs import (
 from arretify.types import DocumentContext, ProtectedTagOrStr, ProtectedTag
 from arretify.utils.functional import iter_func_to_list
 from arretify.regex_utils import PatternProxy, MatchProxy
+from arretify.utils.html_create import make_semantic_tag
 from arretify.utils.html_semantic import (
     SemanticTagSpec,
     get_semantic_tag_data,
     is_semantic_tag,
-    make_semantic_tag,
 )
 from arretify.utils.strings import merge_strings
 from arretify.utils.split_merge import (
@@ -56,7 +56,7 @@ TRANSPARENT_TAG_SPECS: list[SemanticTagSpec] = [PageSeparatorSpec, PageFooterSpe
 List of tag names that are considered transparent for text extraction purposes.
 """
 
-INLINE_TAG_SPECS: list[SemanticTagSpec] = [AddressSpec]
+_STR_TAG_SPECS: list[SemanticTagSpec] = [AddressSpec]
 """
 List of tag names that contains specific bits of text information inside a text_span.
 """
@@ -297,7 +297,7 @@ def get_string(element: ProtectedTagOrStr) -> str:
 def _get_string(element: ProtectedTagOrStr) -> str:
     if isinstance(element, str):
         return element
-    elif is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec, *INLINE_TAG_SPECS]):
+    elif is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec, *_STR_TAG_SPECS]):
         return merge_strings(_get_string(child) for child in element.contents)
     elif is_semantic_tag(element, spec_in=TRANSPARENT_TAG_SPECS):
         return ""
@@ -333,7 +333,7 @@ def combine_text_spans(
             last_text_span = element
             for text_span_child in element.contents:
                 if isinstance(text_span_child, str) or is_semantic_tag(
-                    text_span_child, spec_in=TRANSPARENT_TAG_SPECS + INLINE_TAG_SPECS
+                    text_span_child, spec_in=TRANSPARENT_TAG_SPECS + _STR_TAG_SPECS
                 ):
                     contents.append(text_span_child)
                 else:

--- a/arretify/step_segmentation/core_test.py
+++ b/arretify/step_segmentation/core_test.py
@@ -19,11 +19,11 @@
 import unittest
 
 from arretify.regex_utils import PatternProxy
-from arretify.utils.html_create import make_new_tag
+from arretify.utils.html_create import make_new_tag, make_semantic_tag
 from arretify.utils.testing import create_document_context
 from arretify.utils.html_semantic import (
+    Contents,
     create_semantic_tag_spec_no_data,
-    make_semantic_tag,
 )
 from arretify.semantic_tag_specs import AddressSpec, PageSeparatorData, PageSeparatorSpec
 from .semantic_tag_specs import (
@@ -48,6 +48,11 @@ from .testing import make_text_spans, assert_elements_equal
 SomeTagSpec = create_semantic_tag_spec_no_data(
     spec_name="segmentation:some_tag",
     tag_name=SEGMENTATION_TAG_NAME,
+    allowed_contents=(
+        Contents.Str(),
+        Contents.SemanticTag(TextSpanSegmentationSpec.spec_name),
+        Contents.Tag("some-tag"),
+    ),
 )
 
 
@@ -401,7 +406,7 @@ class TestGetString(BaseTestCase):
             SomeTagSpec,
             contents=[
                 "This is",
-                make_new_tag(self.soup, "not-a-string"),
+                make_new_tag(self.soup, "some-tag"),
                 " a test",
             ],
         )

--- a/arretify/step_segmentation/document_elements.py
+++ b/arretify/step_segmentation/document_elements.py
@@ -36,14 +36,15 @@ from arretify.regex_utils import (
 from arretify.types import DocumentContext, ProtectedTagOrStr, ProtectedTag
 from arretify.utils.strings import split_on_newlines
 from arretify.utils.html_semantic import (
-    make_semantic_tag,
     is_semantic_tag,
 )
 from arretify.utils.html_create import (
+    make_semantic_tag,
     wrap_in_tag,
 )
 from arretify.utils.functional import iter_func_to_list
 from arretify.utils.split_merge import (
+    split_and_map_elements,
     split_elements,
     map_splitted_elements,
 )
@@ -90,15 +91,13 @@ def parse_tables_of_contents(
     context: DocumentContext,
     elements: Sequence[ProtectedTagOrStr],
 ) -> list[ProtectedTagOrStr]:
-    return map_splitted_elements(
-        split_elements(
-            elements,
-            make_while_splitter_for_text_spans(
-                _is_table_of_contents,
-                _table_of_contents_while_condition,
-            ),
+    return split_and_map_elements(
+        elements,
+        make_while_splitter_for_text_spans(
+            _is_table_of_contents,
+            _table_of_contents_while_condition,
         ),
-        lambda pile: make_semantic_tag(context.protected_soup, TableOfContentsSpec, contents=pile),
+        lambda contents: _render_table_of_contents(context, contents),
     )
 
 
@@ -134,8 +133,14 @@ def parse_page_footers(
             elements,
             make_while_splitter_for_text_spans(_is_page_footer, _is_page_footer),
         ),
-        lambda children: make_semantic_tag(
-            context.protected_soup, PageFooterSpec, contents=children
+        lambda contents: make_semantic_tag(
+            context.protected_soup,
+            PageFooterSpec,
+            contents=wrap_in_tag(
+                context.protected_soup,
+                "div",
+                [get_string(e) for e in contents],
+            ),
         ),
     )
 
@@ -165,31 +170,20 @@ def initialize_document_structure(
             )
 
 
-def render_table_of_contents(
+def _render_table_of_contents(
     context: DocumentContext,
-    tag: ProtectedTag,
+    contents: Sequence[ProtectedTagOrStr],
 ) -> ProtectedTag:
-    contents: list[ProtectedTagOrStr] = []
-    for element in tag.contents:
+    rendered_contents: list[ProtectedTagOrStr] = []
+    for element in contents:
         if is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec]):
-            contents.append(get_string(element))
+            rendered_contents.append(get_string(element))
         elif is_semantic_tag(element, spec_in=[PageSeparatorSpec]):
-            contents.append(element)
+            rendered_contents.append(element)
         else:
             raise ValueError(f"Unexpected element in table of contents: {element}")
     return make_semantic_tag(
         context.protected_soup,
         TableOfContentsSpec,
-        contents=wrap_in_tag(context.protected_soup, contents, "div"),
-    )
-
-
-def render_page_footer(
-    context: DocumentContext,
-    tag: ProtectedTag,
-) -> ProtectedTag:
-    return make_semantic_tag(
-        context.protected_soup,
-        PageFooterSpec,
-        contents=wrap_in_tag(context.protected_soup, [get_string(tag)], "div"),
+        contents=wrap_in_tag(context.protected_soup, "div", rendered_contents),
     )

--- a/arretify/step_segmentation/document_elements_test.py
+++ b/arretify/step_segmentation/document_elements_test.py
@@ -18,14 +18,15 @@
 #
 import unittest
 
+from arretify.utils.html_create import make_semantic_tag, wrap_in_tag
+
+
 from .document_elements import (
     initialize_document_structure,
     parse_tables_of_contents,
-    render_table_of_contents,
 )
 from .testing import assert_elements_equal, make_text_spans
-from arretify.utils.testing import create_document_context, normalized_html_str
-from arretify.utils.html_semantic import make_semantic_tag
+from arretify.utils.testing import create_document_context
 from arretify.semantic_tag_specs import PageSeparatorData, PageSeparatorSpec, TableOfContentsSpec
 from .semantic_tag_specs import TextSpanSegmentationData, TextSpanSegmentationSpec
 
@@ -121,58 +122,17 @@ class TestParseTablesOfContents(BaseTestCase):
                 make_semantic_tag(
                     self.soup,
                     TableOfContentsSpec,
-                    contents=make_text_spans(
+                    contents=wrap_in_tag(
                         self.soup,
-                        "Sommaire",
-                        "bla ..... page 1",
-                        "blo ..... page 2",
+                        "div",
+                        [
+                            "Sommaire",
+                            "bla ..... page 1",
+                            "blo ..... page 2",
+                        ],
                     ),
                 ),
                 *make_text_spans(self.soup, "Line 2"),
             ],
             ignore_text_span_data=True,
-        )
-
-
-class TestRenderTableOfContents(BaseTestCase):
-
-    def test_simple_render(self):
-        # Arrange
-        tag = make_semantic_tag(
-            self.soup,
-            TableOfContentsSpec,
-            contents=[
-                make_semantic_tag(
-                    self.soup,
-                    TextSpanSegmentationSpec,
-                    contents=["Sommaire"],
-                    data=TextSpanSegmentationData(start=[0, 0, 0], end=[0, 0, 5]),
-                ),
-                make_semantic_tag(
-                    self.soup,
-                    TextSpanSegmentationSpec,
-                    contents=["bla ..... page 1"],
-                    data=TextSpanSegmentationData(start=[0, 1, 0], end=[0, 1, 5]),
-                ),
-                make_semantic_tag(
-                    self.soup,
-                    TextSpanSegmentationSpec,
-                    contents=["blo ..... page 2"],
-                    data=TextSpanSegmentationData(start=[0, 2, 0], end=[0, 2, 5]),
-                ),
-            ],
-        )
-
-        # Act
-        rendered = render_table_of_contents(self.context, tag)
-
-        # Assert
-        assert normalized_html_str(str(rendered)) == normalized_html_str(
-            """
-            <div data-spec="table_of_contents">
-                <div>Sommaire</div>
-                <div>bla ..... page 1</div>
-                <div>blo ..... page 2</div>
-            </div>
-        """
         )

--- a/arretify/step_segmentation/header.py
+++ b/arretify/step_segmentation/header.py
@@ -23,11 +23,11 @@ from arretify.parsing_utils.dates import DATE_NODE, render_date_regex_tree_match
 from arretify.utils.html import is_tag
 from arretify.utils.html_semantic import (
     SemanticTagSpec,
-    make_semantic_tag,
     is_semantic_tag,
     get_semantic_tag_spec,
 )
 from arretify.utils.html_create import (
+    make_semantic_tag,
     replace_children,
     wrap_in_tag,
     make_new_tag,
@@ -39,7 +39,7 @@ from arretify.semantic_tag_specs import (
     EmblemSpec,
     EntitySpec,
     IdentificationSpec,
-    ArreteSpec,
+    ArreteTitleSpec,
     HonorarySpec,
     VisaSpec,
     MotifSpec,
@@ -47,19 +47,22 @@ from arretify.semantic_tag_specs import (
     PageSeparatorSpec,
     PageFooterSpec,
     TableOfContentsSpec,
+    HeaderSpec,
 )
 from arretify.step_segmentation.semantic_tag_specs import (
     ListSegmentationSpec,
+    MotifSegmentationSpec,
     TextSpanSegmentationSpec,
-    ImageSegmentationSpec,
+    VisaSegmentationSpec,
 )
 from arretify.regex_utils import (
     PatternProxy,
     join_with_or,
 )
 from arretify.utils.split_merge import (
+    Splitter,
+    split_and_map_elements,
     split_elements,
-    SplitMatch,
     map_splitted_elements,
     Probe,
 )
@@ -67,17 +70,90 @@ from .core import (
     make_recombine_interrupted_lines_splitter,
     make_while_splitter_for_text_spans,
     make_single_line_splitter_for_text_spans,
-    group_text_span_tags_splitter,
     make_probe_from_pattern_proxy,
     get_string,
     get_strings,
     TRANSPARENT_TAG_SPECS,
 )
-from .document_elements import (
-    render_page_footer,
-    render_table_of_contents,
-)
-from .basic_elements import parse_lists, render_image, render_list, render_text_span
+from .basic_elements import parse_lists, render_list, render_text_span
+
+
+def parse_header(
+    context: DocumentContext,
+    elements: Sequence[ProtectedTagOrStr],
+) -> list[ProtectedTagOrStr]:
+    elements = chain_functions(
+        context,
+        elements,
+        [
+            parse_emblem_element,
+            parse_entity_element,
+            parse_identification_element,
+            parse_arrete_title_element,
+            parse_honorary_element,
+            parse_supplementary_motif_info_element,
+            # We need to run list parsing here :
+            # - after header elements, because some of them
+            #       might contain lists which we don't want captured.
+            #
+            # - before visas and motifs, because they use list tags
+            #       to build lists of visas / motifs
+            parse_lists,
+        ],
+    )
+    elements = parse_visa_and_motif_elements(context, elements)
+    return elements
+
+
+def render_header(
+    context: DocumentContext,
+    elements: Sequence[ProtectedTagOrStr],
+) -> ProtectedTag:
+    contents: list[ProtectedTagOrStr] = []
+    for element in elements:
+        if is_semantic_tag(element, spec_in=[VisaSegmentationSpec, MotifSegmentationSpec]):
+            contents.append(render_visa_motif(context, element))
+        # All header elements other than the ones above
+        # are treated in a generic way.
+        elif is_semantic_tag(
+            element,
+            spec_in=HEADER_ELEMENTS_SPECS,
+        ):
+            contents.append(element)
+        elif is_semantic_tag(
+            element, spec_in=[PageSeparatorSpec, PageFooterSpec, TableOfContentsSpec]
+        ):
+            contents.append(element)
+        elif is_semantic_tag(element, spec_in=[ListSegmentationSpec]):
+            contents.append(render_list(context, element))
+        elif is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec]):
+            contents.append(
+                make_new_tag(
+                    context.protected_soup,
+                    "div",
+                    contents=render_text_span(context, element),
+                )
+            )
+
+        elif is_tag(element, tag_name_in=["img"]):
+            contents.append(element)
+
+        elif is_semantic_tag(element):
+            raise ValueError(
+                f"Unexpected tag {get_semantic_tag_spec(element).spec_name} in content"
+            )
+
+        elif isinstance(element, str):
+            contents.extend(wrap_in_tag(context.protected_soup, "div", [element]))
+
+    return make_semantic_tag(
+        context.protected_soup,
+        HeaderSpec,
+        contents=contents,
+    )
+
+
+# -------------------- Header elements -------------------- #
 
 
 EMBLEMS_LIST = [
@@ -153,12 +229,6 @@ HONORARIES_LIST = [
 HONORARY_PATTERN = PatternProxy(rf"^\W*({join_with_or(HONORARIES_LIST)})")
 """Detect all honorary titles."""
 
-VISA_PATTERN = PatternProxy(r"^\W*vu(\s*:\s*|\b)(?P<contents>.*)")
-"""Detect if the sentence starts with "vu"."""
-
-MOTIF_PATTERN = PatternProxy(r"^\W*considerant(\s*:\s*|\b)(?P<contents>.*)")
-"""Detect if the sentence starts with "considerant"."""
-
 SUPPLEMENTARY_MOTIF_INFORMATIONS_LIST = [
     r"le (demandeur|petitionnaire) entendu",
     r"l'exploitant entendu",
@@ -175,10 +245,8 @@ HEADER_ELEMENTS_SPECS: Sequence[SemanticTagSpec] = [
     EmblemSpec,
     EntitySpec,
     IdentificationSpec,
-    ArreteSpec,
+    ArreteTitleSpec,
     HonorarySpec,
-    VisaSpec,
-    MotifSpec,
     SupplementaryMotifInfoSpec,
 ]
 
@@ -187,10 +255,8 @@ HEADER_ELEMENTS_PATTERNS: Dict[SemanticTagSpec, PatternProxy] = {
     EmblemSpec: EMBLEM_PATTERN,
     EntitySpec: ENTITY_PATTERN,
     IdentificationSpec: IDENTIFICATION_PATTERN,
-    ArreteSpec: ARRETE_TITLE_PATTERN,
+    ArreteTitleSpec: ARRETE_TITLE_PATTERN,
     HonorarySpec: HONORARY_PATTERN,
-    VisaSpec: VISA_PATTERN,
-    MotifSpec: MOTIF_PATTERN,
     SupplementaryMotifInfoSpec: SUPPLEMENTARY_MOTIF_INFORMATION_PATTERN,
 }
 
@@ -211,113 +277,29 @@ HEADER_ELEMENTS_PROBES: Dict[SemanticTagSpec, Probe[ProtectedTagOrStr]] = {
 
 HEADER_ELEMENTS_FUZZY_PROBES: Dict[SemanticTagSpec, Probe[ProtectedTagOrStr]] = {
     EntitySpec: make_probe_from_pattern_proxy(ENTITY_PATTERN),
-    ArreteSpec: make_probe_from_pattern_proxy(ARRETE_TITLE_PATTERN),
+    ArreteTitleSpec: make_probe_from_pattern_proxy(ARRETE_TITLE_PATTERN),
 }
-
-VISA_MOTIFS_PATTERNS: Dict[SemanticTagSpec, PatternProxy] = {
-    VisaSpec: VISA_PATTERN,
-    MotifSpec: MOTIF_PATTERN,
-}
-
-VISA_MOTIFS_PROBES: Dict[SemanticTagSpec, Probe[ProtectedTagOrStr]] = {
-    VisaSpec: make_probe_from_pattern_proxy(VISA_PATTERN),
-    MotifSpec: make_probe_from_pattern_proxy(MOTIF_PATTERN),
-}
-
-
-def _is_nothing_else_than(spec: SemanticTagSpec, element: ProtectedTagOrStr) -> bool:
-    return is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec]) and not any(
-        bool(HEADER_ELEMENTS_PATTERNS[other_spec].match(get_string(element)))
-        for other_spec in HEADER_ELEMENTS_PATTERNS
-        if other_spec != spec
-    )
-
-
-def parse_header(
-    context: DocumentContext,
-    elements: Sequence[ProtectedTagOrStr],
-) -> list[ProtectedTagOrStr]:
-    elements = chain_functions(
-        context,
-        elements,
-        [
-            parse_emblem_element,
-            parse_entity_element,
-            parse_identification_element,
-            parse_arrete_title_element,
-            parse_honorary_element,
-            parse_supplementary_motif_info_element,
-            # We need to run list parsing here :
-            # - after header elements, because some of them
-            #       might contain lists which we don't want captured.
-            #
-            # - before visas and motifs, because they use list tags
-            #       to build lists of visas / motifs
-            parse_lists,
-        ],
-    )
-    elements = parse_visa_and_motif_elements(context, elements)
-    return elements
-
-
-def _parse_header_element(
-    context: DocumentContext,
-    elements: Sequence[ProtectedTagOrStr],
-    spec: SemanticTagSpec,
-) -> list[ProtectedTagOrStr]:
-    """
-    Generic function to parse header elements.
-    It uses a simple regex pattern to detect the element start,
-    and then gathers all following lines while the pattern still matches.
-    """
-    return map_splitted_elements(
-        split_elements(
-            elements,
-            make_while_splitter_for_text_spans(
-                HEADER_ELEMENTS_PROBES[spec], HEADER_ELEMENTS_PROBES[spec]
-            ),
-        ),
-        lambda contents: make_semantic_tag(context.protected_soup, spec, contents=contents),
-    )
-
-
-def _parse_header_element_fuzzy(
-    context: DocumentContext,
-    elements: Sequence[ProtectedTagOrStr],
-    spec: SemanticTagSpec,
-) -> list[ProtectedTagOrStr]:
-    """
-    Generic function to parse header elements with a fuzzy match.
-    It uses a regex pattern to find the start of the element,
-    and then gathers all following lines that do not match another element.
-    """
-    return map_splitted_elements(
-        split_elements(
-            elements,
-            make_while_splitter_for_text_spans(
-                HEADER_ELEMENTS_FUZZY_PROBES[spec],
-                lambda elements, index: _is_nothing_else_than(spec, elements[index]),
-            ),
-        ),
-        lambda contents: make_semantic_tag(context.protected_soup, spec, contents=contents),
-    )
 
 
 def parse_emblem_element(
     context: DocumentContext,
     elements: Sequence[ProtectedTagOrStr],
 ) -> list[ProtectedTagOrStr]:
-    return _parse_header_element(context, elements, EmblemSpec)
+    return split_and_map_elements(
+        elements,
+        _make_header_elements_splitter(EmblemSpec),
+        lambda contents: _render_header_element(context, EmblemSpec, contents),
+    )
 
 
 def parse_entity_element(
     context: DocumentContext,
     elements: Sequence[ProtectedTagOrStr],
 ) -> list[ProtectedTagOrStr]:
-    return _parse_header_element_fuzzy(
-        context,
+    return split_and_map_elements(
         elements,
-        EntitySpec,
+        _make_header_elements_fuzzy_splitter(EntitySpec),
+        lambda contents: _render_header_element(context, EntitySpec, contents),
     )
 
 
@@ -325,17 +307,21 @@ def parse_identification_element(
     context: DocumentContext,
     elements: Sequence[ProtectedTagOrStr],
 ) -> list[ProtectedTagOrStr]:
-    return _parse_header_element(context, elements, IdentificationSpec)
+    return split_and_map_elements(
+        elements,
+        _make_header_elements_splitter(IdentificationSpec),
+        lambda contents: _render_header_element(context, IdentificationSpec, contents),
+    )
 
 
 def parse_arrete_title_element(
     context: DocumentContext,
     elements: Sequence[ProtectedTagOrStr],
 ) -> list[ProtectedTagOrStr]:
-    return _parse_header_element_fuzzy(
-        context,
+    return split_and_map_elements(
         elements,
-        ArreteSpec,
+        _make_header_elements_fuzzy_splitter(ArreteTitleSpec),
+        lambda contents: _render_arrete_title(context, contents),
     )
 
 
@@ -343,45 +329,142 @@ def parse_honorary_element(
     context: DocumentContext,
     elements: Sequence[ProtectedTagOrStr],
 ) -> list[ProtectedTagOrStr]:
-    return _parse_header_element(context, elements, HonorarySpec)
+    return split_and_map_elements(
+        elements,
+        _make_header_elements_splitter(HonorarySpec),
+        lambda contents: _render_header_element(context, HonorarySpec, contents),
+    )
 
 
 def parse_supplementary_motif_info_element(
     context: DocumentContext,
     elements: Sequence[ProtectedTagOrStr],
 ) -> list[ProtectedTagOrStr]:
-    return _parse_header_element(
-        context,
+    return split_and_map_elements(
         elements,
-        SupplementaryMotifInfoSpec,
+        _make_header_elements_splitter(SupplementaryMotifInfoSpec),
+        lambda contents: _render_header_element(context, SupplementaryMotifInfoSpec, contents),
     )
+
+
+def _make_header_elements_splitter(
+    spec: SemanticTagSpec,
+) -> Splitter[ProtectedTagOrStr, Sequence[ProtectedTagOrStr]]:
+    return make_while_splitter_for_text_spans(
+        HEADER_ELEMENTS_PROBES[spec], HEADER_ELEMENTS_PROBES[spec]
+    )
+
+
+def _make_header_elements_fuzzy_splitter(
+    spec: SemanticTagSpec,
+) -> Splitter[ProtectedTagOrStr, Sequence[ProtectedTagOrStr]]:
+    return make_while_splitter_for_text_spans(
+        HEADER_ELEMENTS_FUZZY_PROBES[spec],
+        lambda elements, index: _is_nothing_else_than(spec, elements[index]),
+    )
+
+
+def _is_nothing_else_than(spec: SemanticTagSpec, element: ProtectedTagOrStr) -> bool:
+    all_patterns: Dict[SemanticTagSpec, PatternProxy] = {
+        **HEADER_ELEMENTS_PATTERNS,
+        **VISA_MOTIFS_PATTERNS,
+    }
+    return is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec]) and not any(
+        bool(all_patterns[other_spec].match(get_string(element)))
+        for other_spec in all_patterns
+        if other_spec != spec
+    )
+
+
+def _render_arrete_title(
+    context: DocumentContext,
+    contents: Sequence[ProtectedTagOrStr],
+) -> ProtectedTag:
+    elements: list[ProtectedTagOrStr] = [" ".join(get_strings(contents))]
+    elements = split_and_map_elements(
+        elements,
+        make_regex_tree_splitter(DATE_NODE),
+        lambda tree_match: render_date_regex_tree_match(context.protected_soup, tree_match),
+    )
+    return make_semantic_tag(
+        context.protected_soup,
+        ArreteTitleSpec,
+        contents=[make_new_tag(context.protected_soup, "h1", contents=elements)],
+    )
+
+
+def _render_header_element(
+    context: DocumentContext,
+    spec: SemanticTagSpec,
+    contents: Sequence[ProtectedTagOrStr],
+) -> ProtectedTag:
+    if not all(is_semantic_tag(c, spec_in=[TextSpanSegmentationSpec]) for c in contents):
+        raise ValueError(f"Invalid contents for {spec}: {contents}")
+
+    rendered_contents: list[ProtectedTagOrStr] = []
+    pattern = HEADER_ELEMENTS_RENDER_PATTERNS[spec]
+    strings = get_strings(contents)
+    if pattern is not None:
+        rendered_contents.extend(join_split_pile_with_pattern(strings, pattern))
+    else:
+        rendered_contents.extend(strings)
+
+    return make_semantic_tag(
+        context.protected_soup,
+        spec,
+        contents=wrap_in_tag(context.protected_soup, "div", rendered_contents),
+    )
+
+
+# -------------------- Visa and Motifs -------------------- #
+
+VISA_PATTERN = PatternProxy(r"^\W*vu(\s*:\s*|\b)(?P<contents>.*)")
+"""Detect if the sentence starts with "vu"."""
+
+MOTIF_PATTERN = PatternProxy(r"^\W*considerant(\s*:\s*|\b)(?P<contents>.*)")
+"""Detect if the sentence starts with "considerant"."""
+
+VISA_MOTIFS_PATTERNS: Dict[SemanticTagSpec, PatternProxy] = {
+    VisaSegmentationSpec: VISA_PATTERN,
+    MotifSegmentationSpec: MOTIF_PATTERN,
+}
+
+VISA_MOTIFS_PROBES: Dict[SemanticTagSpec, Probe[ProtectedTagOrStr]] = {
+    VisaSegmentationSpec: make_probe_from_pattern_proxy(VISA_PATTERN),
+    MotifSegmentationSpec: make_probe_from_pattern_proxy(MOTIF_PATTERN),
+}
+
+VISA_MOTIFS_RENDER_SPECS: Dict[SemanticTagSpec, SemanticTagSpec] = {
+    VisaSegmentationSpec: VisaSpec,
+    MotifSegmentationSpec: MotifSpec,
+}
 
 
 def parse_visa_and_motif_elements(
     context: DocumentContext,
     elements: Sequence[ProtectedTagOrStr],
 ) -> list[ProtectedTagOrStr]:
-    elements = _parse_visa_and_motif_elements_pass1(context, elements, VisaSpec)
-    elements = _parse_visa_and_motif_elements_pass1(context, elements, MotifSpec)
+    elements = _parse_visa_and_motif_elements_pass1(context, elements, VisaSegmentationSpec)
+    elements = _parse_visa_and_motif_elements_pass1(context, elements, MotifSegmentationSpec)
     elements = _parse_visa_and_motif_elements_pass2(
         context,
         elements,
-        spec=VisaSpec,
+        spec=VisaSegmentationSpec,
     )
     elements = _parse_visa_and_motif_elements_pass3(
         context,
         elements,
-        spec=VisaSpec,
+        spec=VisaSegmentationSpec,
     )
     elements = _parse_visa_and_motif_elements_pass2(
         context,
         elements,
-        spec=MotifSpec,
+        spec=MotifSegmentationSpec,
     )
     elements = _parse_visa_and_motif_elements_pass3(
         context,
         elements,
-        spec=MotifSpec,
+        spec=MotifSegmentationSpec,
     )
     return elements
 
@@ -480,11 +563,10 @@ def _parse_visa_and_motif_elements_pass2(
         yield from first_tag.contents
         while elements:
             element = elements[0]
-            # We're a bit lenient here and accept a few unassigned_line tags,
-            # as random text sometimes interferes with the parsing.
-            if is_semantic_tag(element, spec_in=TRANSPARENT_TAG_SPECS) or is_semantic_tag(
-                element, spec_in=[TextSpanSegmentationSpec]
-            ):
+            # We're a bit lenient here and accept a few extra tags,
+            # as random text sometimes interferes with the parsing
+            # (e.g. some page footer text that we couldn't filter out before).
+            if is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec, *TRANSPARENT_TAG_SPECS]):
                 yield elements.pop(0)
 
             elif is_semantic_tag(element, spec_in=[ListSegmentationSpec]):
@@ -526,7 +608,9 @@ def _parse_visa_and_motif_elements_pass2(
 def _recombine_visa_motif_with_next_if_continuing_sentence(
     elements: Sequence[ProtectedTagOrStr],
 ) -> ProtectedTag:
-    assert len(elements) > 0 and is_semantic_tag(elements[0], spec_in=[VisaSpec, MotifSpec])
+    assert len(elements) > 0 and is_semantic_tag(
+        elements[0], spec_in=[VisaSegmentationSpec, MotifSegmentationSpec]
+    )
     return replace_children(elements[0], elements[0].contents + list(elements[1:]))
 
 
@@ -565,84 +649,13 @@ def _parse_visa_and_motif_elements_pass3(
             yield element
 
 
-@iter_func_to_list
-def render_header(
-    context: DocumentContext,
-    elements: Sequence[ProtectedTagOrStr],
-) -> Iterator[ProtectedTag]:
-    for element in elements:
-        if is_semantic_tag(element, spec_in=[ArreteSpec]):
-            yield render_arrete_title(context, element)
-        elif is_semantic_tag(element, spec_in=[VisaSpec, MotifSpec]):
-            yield render_visa_motif(context, element)
-        # All header elements other than the ones above
-        # are treated in a generic way.
-        elif is_semantic_tag(
-            element,
-            spec_in=HEADER_ELEMENTS_SPECS,
-        ):
-            yield render_header_element(context, element)
-        elif is_semantic_tag(element, spec_in=[TableOfContentsSpec]):
-            yield render_table_of_contents(context, element)
-        elif is_semantic_tag(element, spec_in=[PageSeparatorSpec]):
-            yield element
-        elif is_semantic_tag(element, spec_in=[PageFooterSpec]):
-            yield render_page_footer(context, element)
-        elif is_semantic_tag(element, spec_in=[ImageSegmentationSpec]):
-            yield render_image(context, element)
-        elif is_semantic_tag(element, spec_in=[ListSegmentationSpec]):
-            yield render_list(context, element)
-        elif is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec]):
-            yield make_new_tag(
-                context.protected_soup,
-                "div",
-                contents=render_text_span(context, element),
-            )
-
-        elif is_semantic_tag(element):
-            raise ValueError(
-                f"Unexpected tag {get_semantic_tag_spec(element).spec_name} in content"
-            )
-
-        elif isinstance(element, str):
-            yield from wrap_in_tag(context.protected_soup, [element], "div")
-
-
-def render_header_element(
-    context: DocumentContext,
-    tag: ProtectedTag,
-) -> ProtectedTag:
-    contents: list[ProtectedTagOrStr] = []
-    spec = get_semantic_tag_spec(tag)
-    pattern = HEADER_ELEMENTS_RENDER_PATTERNS[spec]
-
-    elements: Sequence[ProtectedTagOrStr] = tag.contents
-    for splitted_element in split_elements(
-        elements,
-        group_text_span_tags_splitter,
-    ):
-        if isinstance(splitted_element, SplitMatch):
-            strings = get_strings(splitted_element.value)
-            if pattern is not None:
-                contents.extend(join_split_pile_with_pattern(strings, pattern))
-            else:
-                contents.extend(strings)
-
-        else:
-            raise ValueError(f"Unexpected element {splitted_element.value} in header elements")
-
-    return replace_children(
-        tag,
-        wrap_in_tag(context.protected_soup, contents, "div"),
-    )
-
-
 def render_visa_motif(
     context: DocumentContext,
     tag: ProtectedTag,
 ) -> ProtectedTag:
-    assert is_semantic_tag(tag, spec_in=[VisaSpec, MotifSpec])
+    assert is_semantic_tag(tag, spec_in=[VisaSegmentationSpec, MotifSegmentationSpec])
     contents: list[ProtectedTagOrStr] = []
+    spec = get_semantic_tag_spec(tag)
 
     for element in tag.contents:
         if is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec]):
@@ -654,28 +667,8 @@ def render_visa_motif(
         else:
             raise ValueError(f"Unexpected element {element} in visa/motif")
 
-    return replace_children(
-        tag,
-        contents,
-    )
-
-
-def render_arrete_title(
-    context: DocumentContext,
-    tag: ProtectedTag,
-) -> ProtectedTag:
-    elements: list[ProtectedTagOrStr] = [" ".join(get_strings(tag.contents))]
-    # TODO : Parsing date should be done in a tag and not on the fly
-    # like this.
-    elements = map_splitted_elements(
-        split_elements(
-            elements,
-            make_regex_tree_splitter(DATE_NODE),
-        ),
-        lambda tree_match: render_date_regex_tree_match(context.protected_soup, tree_match),
-    )
     return make_semantic_tag(
         context.protected_soup,
-        ArreteSpec,
-        contents=[make_new_tag(context.protected_soup, "h1", contents=elements)],
+        VISA_MOTIFS_RENDER_SPECS[spec],
+        contents=contents,
     )

--- a/arretify/step_segmentation/header_test.py
+++ b/arretify/step_segmentation/header_test.py
@@ -18,26 +18,35 @@
 #
 import unittest
 
+from arretify.utils.html_create import make_new_tag, make_semantic_tag, wrap_in_tag
 from arretify.utils.testing import create_document_context, normalized_html_str
-from arretify.utils.html_semantic import make_semantic_tag
 from arretify.semantic_tag_specs import (
+    DateSpec,
+    HonorarySpec,
+    IdentificationSpec,
     PageSeparatorData,
-    VisaSpec,
-    MotifSpec,
     PageSeparatorSpec,
     PageFooterSpec,
     EmblemSpec,
     EntitySpec,
-    ArreteSpec,
+    ArreteTitleSpec,
+    SupplementaryMotifInfoSpec,
 )
-from arretify.step_segmentation.semantic_tag_specs import ListSegmentationSpec
+from arretify.step_segmentation.semantic_tag_specs import (
+    ListSegmentationSpec,
+    MotifSegmentationSpec,
+    VisaSegmentationSpec,
+)
 from .header import (
+    _render_header_element,
     parse_visa_and_motif_elements,
-    _parse_header_element,
-    _parse_header_element_fuzzy,
-    render_header_element,
     render_visa_motif,
-    render_arrete_title,
+    parse_arrete_title_element,
+    parse_emblem_element,
+    parse_entity_element,
+    parse_identification_element,
+    parse_honorary_element,
+    parse_supplementary_motif_info_element,
 )
 from .testing import assert_elements_equal, make_text_spans
 
@@ -73,7 +82,7 @@ class TestParseVisaAndMotifs(BaseTestCase):
             [
                 make_semantic_tag(
                     self.soup,
-                    VisaSpec,
+                    VisaSegmentationSpec,
                     contents=make_text_spans(
                         self.soup,
                         (
@@ -84,7 +93,7 @@ class TestParseVisaAndMotifs(BaseTestCase):
                 ),
                 make_semantic_tag(
                     self.soup,
-                    VisaSpec,
+                    VisaSegmentationSpec,
                     contents=make_text_spans(
                         self.soup,
                         (
@@ -114,11 +123,11 @@ class TestParseVisaAndMotifs(BaseTestCase):
             result,
             [
                 make_semantic_tag(
-                    self.soup, VisaSpec, contents=make_text_spans(self.soup, "Vu bla")
+                    self.soup, VisaSegmentationSpec, contents=make_text_spans(self.soup, "Vu bla")
                 ),
                 *make_text_spans(self.soup, "Ceci est du texte aléatoire qui n'est pas un visa."),
                 make_semantic_tag(
-                    self.soup, VisaSpec, contents=make_text_spans(self.soup, "Vu blo")
+                    self.soup, VisaSegmentationSpec, contents=make_text_spans(self.soup, "Vu blo")
                 ),
             ],
             ignore_text_span_data=True,
@@ -147,12 +156,12 @@ class TestParseVisaAndMotifs(BaseTestCase):
             [
                 make_semantic_tag(
                     self.soup,
-                    MotifSpec,
+                    MotifSegmentationSpec,
                     contents=make_text_spans(self.soup, "- Considérant que blabla ;"),
                 ),
                 make_semantic_tag(
                     self.soup,
-                    MotifSpec,
+                    MotifSegmentationSpec,
                     contents=make_text_spans(self.soup, "- Considérant que bloblo ;"),
                 ),
             ],
@@ -178,7 +187,7 @@ class TestParseVisaAndMotifs(BaseTestCase):
             [
                 make_semantic_tag(
                     self.soup,
-                    VisaSpec,
+                    VisaSegmentationSpec,
                     contents=[
                         *make_text_spans(
                             self.soup,
@@ -215,14 +224,18 @@ class TestParseVisaAndMotifs(BaseTestCase):
             [
                 *make_text_spans(self.soup, "CONSIDÉRANT : "),
                 make_semantic_tag(
-                    self.soup, MotifSpec, contents=make_text_spans(self.soup, "que blabla ;")
-                ),
-                make_semantic_tag(
-                    self.soup, MotifSpec, contents=make_text_spans(self.soup, "que bloblo ;")
+                    self.soup,
+                    MotifSegmentationSpec,
+                    contents=make_text_spans(self.soup, "que blabla ;"),
                 ),
                 make_semantic_tag(
                     self.soup,
-                    MotifSpec,
+                    MotifSegmentationSpec,
+                    contents=make_text_spans(self.soup, "que bloblo ;"),
+                ),
+                make_semantic_tag(
+                    self.soup,
+                    MotifSegmentationSpec,
                     contents=make_text_spans(self.soup, "qu'en application de blibli ;"),
                 ),
             ],
@@ -241,7 +254,9 @@ class TestParseVisaAndMotifs(BaseTestCase):
                 ),
             ),
             make_semantic_tag(
-                self.soup, PageFooterSpec, contents=make_text_spans(self.soup, "page 1")
+                self.soup,
+                PageFooterSpec,
+                contents=wrap_in_tag(self.soup, "div", ["page 1"]),
             ),
             *make_text_spans(
                 self.soup,
@@ -262,7 +277,7 @@ class TestParseVisaAndMotifs(BaseTestCase):
                 *make_text_spans(self.soup, "Vu : "),
                 make_semantic_tag(
                     self.soup,
-                    VisaSpec,
+                    VisaSegmentationSpec,
                     contents=make_text_spans(
                         self.soup,
                         "le code de l'environnement, et notamment ses titres "
@@ -270,11 +285,13 @@ class TestParseVisaAndMotifs(BaseTestCase):
                     ),
                 ),
                 make_semantic_tag(
-                    self.soup, PageFooterSpec, contents=make_text_spans(self.soup, "page 1")
+                    self.soup,
+                    PageFooterSpec,
+                    contents=wrap_in_tag(self.soup, "div", ["page 1"]),
                 ),
                 make_semantic_tag(
                     self.soup,
-                    VisaSpec,
+                    VisaSegmentationSpec,
                     contents=make_text_spans(
                         self.soup,
                         "la nomenclature des installations classées codifiée à l'annexe "
@@ -310,12 +327,12 @@ class TestParseVisaAndMotifs(BaseTestCase):
                 *make_text_spans(self.soup, "Vu : "),
                 make_semantic_tag(
                     self.soup,
-                    VisaSpec,
+                    VisaSegmentationSpec,
                     contents=make_text_spans(self.soup, "- le code de l'environnement ;"),
                 ),
                 make_semantic_tag(
                     self.soup,
-                    VisaSpec,
+                    VisaSegmentationSpec,
                     contents=make_text_spans(
                         self.soup, "- la nomenclature des installations classées ;"
                     ),
@@ -353,13 +370,13 @@ class TestParseVisaAndMotifs(BaseTestCase):
                 *make_text_spans(self.soup, "Vu : "),
                 make_semantic_tag(
                     self.soup,
-                    VisaSpec,
+                    VisaSegmentationSpec,
                     contents=make_text_spans(self.soup, "- le code de l'environnement ;"),
                 ),
                 *make_text_spans(self.soup, "Ceci est du texte aléatoire qui n'est pas un visa."),
                 make_semantic_tag(
                     self.soup,
-                    VisaSpec,
+                    VisaSegmentationSpec,
                     contents=make_text_spans(
                         self.soup, "- la nomenclature des installations classées ;"
                     ),
@@ -394,19 +411,19 @@ class TestParseVisaAndMotifs(BaseTestCase):
                 *make_text_spans(self.soup, "Vu : "),
                 make_semantic_tag(
                     self.soup,
-                    VisaSpec,
+                    VisaSegmentationSpec,
                     contents=make_text_spans(self.soup, "- le code de l'environnement ;"),
                 ),
                 make_semantic_tag(
                     self.soup,
-                    VisaSpec,
+                    VisaSegmentationSpec,
                     contents=make_text_spans(
                         self.soup, "- la nomenclature des installations classées ;"
                     ),
                 ),
                 make_semantic_tag(
                     self.soup,
-                    VisaSpec,
+                    VisaSegmentationSpec,
                     contents=make_text_spans(
                         self.soup, "- vu la demande déposée par la société XYZ ;"
                     ),
@@ -444,7 +461,7 @@ class TestParseVisaAndMotifs(BaseTestCase):
             [
                 make_semantic_tag(
                     self.soup,
-                    MotifSpec,
+                    MotifSegmentationSpec,
                     contents=[
                         *make_text_spans(
                             self.soup,
@@ -477,88 +494,208 @@ class TestRenderHeaderElement(BaseTestCase):
 
     def test_render_header_element(self):
         # Arrange
-        tag = make_semantic_tag(
-            self.soup,
-            EmblemSpec,
-            contents=make_text_spans(self.soup, "liberté égalité fraternité"),
-        )
+        contents = make_text_spans(self.soup, "liberté égalité fraternité")
 
         # Act
-        rendered = render_header_element(self.context, tag)
+        rendered = _render_header_element(self.context, EmblemSpec, contents)
 
         # Assert
-        assert normalized_html_str(str(rendered)) == normalized_html_str(
-            """
-            <div data-spec="emblem">
-                <div>liberté</div>
-                <div>égalité</div>
-                <div>fraternité</div>
-            </div>
-            """
-        )
+        assert [str(tag) for tag in rendered] == [
+            "<div>liberté </div>",
+            "<div>égalité </div>",
+            "<div>fraternité</div>",
+        ]
 
 
-class TestParseHeaderElement(BaseTestCase):
+class TestParseArreteTitle(BaseTestCase):
 
-    def test_parse_header_element(self):
+    def test_simple(self):
         # Arrange
-        elements = make_text_spans(
+        contents = make_text_spans(
             self.soup,
-            "liberte",
-            "égalité",
-            "fraternité",
+            # Fuzzy pattern, match until next header element
+            "Arrêté du 1er janvier 2020",
+            "Vu le blabla",
         )
 
         # Act
-        elements = _parse_header_element(self.context, elements, EmblemSpec)
+        results = parse_arrete_title_element(self.context, contents)
 
         # Assert
         assert_elements_equal(
-            elements,
+            results,
+            [
+                make_semantic_tag(
+                    self.soup,
+                    ArreteTitleSpec,
+                    contents=[
+                        make_new_tag(
+                            self.soup,
+                            "h1",
+                            contents=[
+                                "Arrêté du ",
+                                make_semantic_tag(
+                                    self.soup, DateSpec, contents=["1er janvier 2020"]
+                                ),
+                            ],
+                        )
+                    ],
+                ),
+                *make_text_spans(self.soup, "Vu le blabla"),
+            ],
+            ignore_text_span_data=True,
+        )
+
+
+class TestParseEmblemElement(BaseTestCase):
+
+    def test_simple(self):
+        # Arrange
+        contents = make_text_spans(self.soup, "liberté égalité fraternité")
+
+        # Act
+        results = parse_emblem_element(self.context, contents)
+
+        # Assert
+        assert_elements_equal(
+            results,
             [
                 make_semantic_tag(
                     self.soup,
                     EmblemSpec,
-                    contents=make_text_spans(
+                    contents=wrap_in_tag(
                         self.soup,
-                        "liberte",
-                        "égalité",
-                        "fraternité",
+                        "div",
+                        [
+                            "liberté ",
+                            "égalité ",
+                            "fraternité",
+                        ],
                     ),
                 ),
             ],
             ignore_text_span_data=True,
         )
 
-    def test_parse_header_element_fuzzy(self):
+
+class TestParseEntityElement(BaseTestCase):
+
+    def test_simple(self):
         # Arrange
-        elements = make_text_spans(
-            self.soup,
-            "prefecture de la région",
-            "basée à Naboo",
-            # Arrete title : should not be included in the entity
-            "Arrêté du 1er janvier 2020",
-        )
+        contents = make_text_spans(self.soup, "Ministère de la Transition écologique")
 
         # Act
-        elements = _parse_header_element_fuzzy(self.context, elements, EntitySpec)
+        results = parse_entity_element(self.context, contents)
 
         # Assert
         assert_elements_equal(
-            elements,
+            results,
             [
                 make_semantic_tag(
                     self.soup,
                     EntitySpec,
-                    contents=make_text_spans(
+                    contents=wrap_in_tag(
                         self.soup,
-                        "prefecture de la région",
-                        "basée à Naboo",
+                        "div",
+                        [
+                            "Ministère de la Transition écologique",
+                        ],
                     ),
                 ),
-                *make_text_spans(
+            ],
+            ignore_text_span_data=True,
+        )
+
+
+class TestParseIdentificationElement(BaseTestCase):
+
+    def test_simple(self):
+        # Arrange
+        contents = make_text_spans(self.soup, "Référence : 2020-1234")
+
+        # Act
+        results = parse_identification_element(self.context, contents)
+
+        # Assert
+        assert_elements_equal(
+            results,
+            [
+                make_semantic_tag(
                     self.soup,
-                    "Arrêté du 1er janvier 2020",
+                    IdentificationSpec,
+                    contents=wrap_in_tag(
+                        self.soup,
+                        "div",
+                        [
+                            "Référence : 2020-1234",
+                        ],
+                    ),
+                ),
+            ],
+            ignore_text_span_data=True,
+        )
+
+
+class TestParseHonoraryElement(BaseTestCase):
+    def test_simple(self):
+        # Arrange
+        contents = make_text_spans(
+            self.soup, "La Directrice Générale de l'Agence Régionale de Santé Grand Est"
+        )
+
+        # Act
+        results = parse_honorary_element(self.context, contents)
+
+        # Assert
+        assert_elements_equal(
+            results,
+            [
+                make_semantic_tag(
+                    self.soup,
+                    HonorarySpec,
+                    contents=wrap_in_tag(
+                        self.soup,
+                        "div",
+                        [
+                            "La Directrice Générale de l'Agence Régionale de Santé Grand Est",
+                        ],
+                    ),
+                ),
+            ],
+            ignore_text_span_data=True,
+        )
+
+
+class TestParseSupplementaryMotifInfo(BaseTestCase):
+
+    def test_simple(self):
+        # Arrange
+        contents = make_text_spans(
+            self.soup,
+            (
+                "Sur proposition de M. le directeur régional de l'environnement,"
+                " de l'aménagement et du logement des Hauts-de-France ;"
+            ),
+        )
+
+        # Act
+        results = parse_supplementary_motif_info_element(self.context, contents)
+
+        # Assert
+        assert_elements_equal(
+            results,
+            [
+                make_semantic_tag(
+                    self.soup,
+                    SupplementaryMotifInfoSpec,
+                    contents=wrap_in_tag(
+                        self.soup,
+                        "div",
+                        [
+                            "Sur proposition de M. le directeur régional de l'environnement,"
+                            " de l'aménagement et du logement des Hauts-de-France ;",
+                        ],
+                    ),
                 ),
             ],
             ignore_text_span_data=True,
@@ -571,7 +708,7 @@ class TestRenderVisaMotif(BaseTestCase):
         # Arrange
         tag = make_semantic_tag(
             self.soup,
-            VisaSpec,
+            VisaSegmentationSpec,
             contents=make_text_spans(
                 self.soup,
                 "Vu le code de l'environnement, et notamment ses titres "
@@ -588,36 +725,6 @@ class TestRenderVisaMotif(BaseTestCase):
             <div data-spec="visa">
                 Vu le code de l'environnement, et notamment ses titres
                 1er et 4 des parties réglementaires et législatives du livre V ;
-            </div>
-            """
-        )
-
-
-class TestRenderArreteTitle(BaseTestCase):
-
-    def test_render_arrete_title(self):
-        # Arrange
-        tag = make_semantic_tag(
-            self.soup,
-            ArreteSpec,
-            contents=make_text_spans(
-                self.soup,
-                "Arrêté du 1er janvier 2020",
-            ),
-        )
-
-        # Act
-        rendered = render_arrete_title(self.context, tag)
-
-        # Assert
-        assert normalized_html_str(str(rendered)) == normalized_html_str(
-            """
-            <div data-spec="arrete_title">
-                <h1>Arrêté du
-                    <time data-spec="date" datetime="2020-01-01">
-                        1er janvier 2020
-                    </time>
-                </h1>
             </div>
             """
         )

--- a/arretify/step_segmentation/parse_arrete.py
+++ b/arretify/step_segmentation/parse_arrete.py
@@ -21,11 +21,9 @@ from typing import Iterator, Callable, Sequence
 from arretify.types import DocumentContext, SectionType, ProtectedTagOrStr
 from arretify.semantic_tag_specs import (
     AppendixSpec,
-    HeaderSpec,
     MainSpec,
 )
-from arretify.utils.html_semantic import make_semantic_tag, is_semantic_tag
-from arretify.utils.html_create import replace_children
+from arretify.utils.html_create import make_semantic_tag, replace_children, is_semantic_tag
 from arretify.utils.functional import chain_functions, iter_func_to_list
 from arretify.utils.split_merge import (
     split_before_match,
@@ -37,7 +35,12 @@ from .core import (
     pick_text_spans,
     get_string,
 )
-from .semantic_tag_specs import TextSpanSegmentationSpec
+from .semantic_tag_specs import (
+    AppendixSegmentationSpec,
+    HeaderSegmentationSpec,
+    MainSegmentationSpec,
+    TextSpanSegmentationSpec,
+)
 from .basic_elements import parse_images, parse_addresses
 from .document_elements import (
     parse_page_footers,
@@ -88,17 +91,21 @@ def parse_arrete(context: DocumentContext, pages: Sequence[str]) -> Iterator[Pro
     # Header
     pile, elements = split_before_match(elements, _is_title_line)
     yield make_semantic_tag(
-        context.protected_soup, HeaderSpec, contents=parse_header(context, pile)
+        context.protected_soup, HeaderSegmentationSpec, contents=parse_header(context, pile)
     )
 
     # Main content
     pile, elements = split_before_match(elements, _is_appendix)
-    yield make_semantic_tag(context.protected_soup, MainSpec, contents=parse_content(context, pile))
+    yield make_semantic_tag(
+        context.protected_soup, MainSegmentationSpec, contents=parse_content(context, pile)
+    )
 
     # Appendix
     if elements:
         yield make_semantic_tag(
-            context.protected_soup, AppendixSpec, contents=parse_content(context, elements)
+            context.protected_soup,
+            AppendixSegmentationSpec,
+            contents=parse_content(context, elements),
         )
 
 
@@ -107,12 +114,12 @@ def render_arrete(
     context: DocumentContext, elements: Sequence[ProtectedTagOrStr]
 ) -> Iterator[ProtectedTagOrStr]:
     for element in elements:
-        if is_semantic_tag(element, spec_in=[HeaderSpec]):
-            yield replace_children(element, render_header(context, element.contents))
-        elif is_semantic_tag(element, spec_in=[MainSpec]):
-            yield replace_children(element, render_content(context, element.contents))
-        elif is_semantic_tag(element, spec_in=[AppendixSpec]):
-            yield replace_children(element, render_content(context, element.contents))
+        if is_semantic_tag(element, spec_in=[HeaderSegmentationSpec]):
+            yield render_header(context, element.contents)
+        elif is_semantic_tag(element, spec_in=[MainSegmentationSpec]):
+            yield render_content(context, MainSpec, element.contents)
+        elif is_semantic_tag(element, spec_in=[AppendixSegmentationSpec]):
+            yield render_content(context, AppendixSpec, element.contents)
 
 
 def _make_text_span_parser(

--- a/arretify/step_segmentation/parse_arrete_test.py
+++ b/arretify/step_segmentation/parse_arrete_test.py
@@ -18,20 +18,20 @@
 #
 import unittest
 
+from arretify.utils.html_create import make_semantic_tag, wrap_in_tag
 from arretify.utils.testing import create_document_context
-from arretify.utils.html_semantic import make_semantic_tag
 from arretify.semantic_tag_specs import (
     AlineaData,
-    HeaderSpec,
-    MainSpec,
-    AppendixSpec,
     PageSeparatorData,
     PageSeparatorSpec,
-    ArreteSpec,
-    AlineaSpec,
+    ArreteTitleSpec,
     AddressSpec,
 )
 from .semantic_tag_specs import (
+    AlineaSegmentationSpec,
+    AppendixSegmentationSpec,
+    HeaderSegmentationSpec,
+    MainSegmentationSpec,
     SectionSegmentationSpec,
     SectionTitleSegmentationData,
     SectionTitleSegmentationSpec,
@@ -71,21 +71,21 @@ class TestParseArrete(BaseTestCase):
             [
                 make_semantic_tag(
                     self.soup,
-                    HeaderSpec,
+                    HeaderSegmentationSpec,
                     contents=[
                         make_semantic_tag(
                             self.soup, PageSeparatorSpec, data=PageSeparatorData(page_index=0)
                         ),
                         make_semantic_tag(
                             self.soup,
-                            ArreteSpec,
-                            contents=make_text_spans(self.soup, "Arrêté n° 123"),
+                            ArreteTitleSpec,
+                            contents=wrap_in_tag(self.soup, "h1", ["Arrêté n° 123"]),
                         ),
                     ],
                 ),
                 make_semantic_tag(
                     self.soup,
-                    MainSpec,
+                    MainSegmentationSpec,
                     contents=[
                         make_semantic_tag(
                             self.soup,
@@ -104,7 +104,7 @@ class TestParseArrete(BaseTestCase):
                                 ),
                                 make_semantic_tag(
                                     self.soup,
-                                    AlineaSpec,
+                                    AlineaSegmentationSpec,
                                     contents=make_text_spans(self.soup, "Bla bla bla ..."),
                                     data=AlineaData(number=1),
                                 ),
@@ -114,7 +114,7 @@ class TestParseArrete(BaseTestCase):
                 ),
                 make_semantic_tag(
                     self.soup,
-                    AppendixSpec,
+                    AppendixSegmentationSpec,
                     contents=[
                         make_semantic_tag(
                             self.soup,
@@ -133,7 +133,7 @@ class TestParseArrete(BaseTestCase):
                                 ),
                                 make_semantic_tag(
                                     self.soup,
-                                    AlineaSpec,
+                                    AlineaSegmentationSpec,
                                     contents=make_text_spans(self.soup, "Bla bla bla ..."),
                                     data=AlineaData(number=1),
                                 ),
@@ -167,21 +167,21 @@ class TestParseArrete(BaseTestCase):
             [
                 make_semantic_tag(
                     self.soup,
-                    HeaderSpec,
+                    HeaderSegmentationSpec,
                     contents=[
                         make_semantic_tag(
                             self.soup, PageSeparatorSpec, data=PageSeparatorData(page_index=0)
                         ),
                         make_semantic_tag(
                             self.soup,
-                            ArreteSpec,
-                            contents=make_text_spans(self.soup, "Arrêté n° 123"),
+                            ArreteTitleSpec,
+                            contents=wrap_in_tag(self.soup, "h1", ["Arrêté n° 123"]),
                         ),
                     ],
                 ),
                 make_semantic_tag(
                     self.soup,
-                    MainSpec,
+                    MainSegmentationSpec,
                     contents=[
                         make_semantic_tag(
                             self.soup,
@@ -200,7 +200,7 @@ class TestParseArrete(BaseTestCase):
                                 ),
                                 make_semantic_tag(
                                     self.soup,
-                                    AlineaSpec,
+                                    AlineaSegmentationSpec,
                                     contents=[
                                         make_semantic_tag(
                                             self.soup,

--- a/arretify/step_segmentation/semantic_tag_specs.py
+++ b/arretify/step_segmentation/semantic_tag_specs.py
@@ -17,7 +17,18 @@
 # limitations under the License.
 #
 from pydantic import field_validator
+from arretify.semantic_tag_specs import (
+    AlineaData,
+    ArreteTitleSpec,
+    EmblemSpec,
+    EntitySpec,
+    HonorarySpec,
+    IdentificationSpec,
+    SupplementaryMotifInfoSpec,
+    TableOfContentsSpec,
+)
 from arretify.utils.html_semantic import (
+    Contents,
     IntList,
     SemanticTagSpec,
     SemanticTagData,
@@ -29,35 +40,7 @@ SEGMENTATION_TAG_NAME = "arretify-segmentation"
 Name of the tag used for segmentation tags.
 """
 
-
-TableSegmentationSpec = create_semantic_tag_spec_no_data(
-    spec_name="segmentation:table",
-    tag_name=SEGMENTATION_TAG_NAME,
-)
-
-
-TableDescriptionSegmentationSpec = create_semantic_tag_spec_no_data(
-    spec_name="segmentation:table_description",
-    tag_name=SEGMENTATION_TAG_NAME,
-)
-
-
-ListSegmentationSpec = create_semantic_tag_spec_no_data(
-    spec_name="segmentation:list",
-    tag_name=SEGMENTATION_TAG_NAME,
-)
-
-
-BlockquoteSegmentationSpec = create_semantic_tag_spec_no_data(
-    spec_name="segmentation:blockquote",
-    tag_name=SEGMENTATION_TAG_NAME,
-)
-
-
-ImageSegmentationSpec = create_semantic_tag_spec_no_data(
-    spec_name="segmentation:image",
-    tag_name=SEGMENTATION_TAG_NAME,
-)
+# -------------------- Basic elements -------------------- #
 
 
 class TextSpanSegmentationData(SemanticTagData):
@@ -80,6 +63,64 @@ TextSpanSegmentationSpec: SemanticTagSpec[TextSpanSegmentationData] = SemanticTa
     spec_name="segmentation:text_span",
     tag_name=SEGMENTATION_TAG_NAME,
     data_model=TextSpanSegmentationData,
+    allowed_contents=(Contents.Str(),),
+)
+
+
+TableSegmentationSpec = create_semantic_tag_spec_no_data(
+    spec_name="segmentation:table",
+    tag_name=SEGMENTATION_TAG_NAME,
+    allowed_contents=(Contents.SemanticTag(TextSpanSegmentationSpec.spec_name),),
+)
+
+
+TableDescriptionSegmentationSpec = create_semantic_tag_spec_no_data(
+    spec_name="segmentation:table_description",
+    tag_name=SEGMENTATION_TAG_NAME,
+    allowed_contents=(Contents.SemanticTag(TextSpanSegmentationSpec.spec_name),),
+)
+
+
+ListSegmentationSpec = create_semantic_tag_spec_no_data(
+    spec_name="segmentation:list",
+    tag_name=SEGMENTATION_TAG_NAME,
+    allowed_contents=(
+        Contents.SemanticTag(TextSpanSegmentationSpec.spec_name),
+        Contents.SemanticTag("segmentation:list"),
+    ),
+)
+
+
+BlockquoteSegmentationSpec = create_semantic_tag_spec_no_data(
+    spec_name="segmentation:blockquote",
+    tag_name=SEGMENTATION_TAG_NAME,
+    allowed_contents=(
+        Contents.SemanticTag(TextSpanSegmentationSpec.spec_name),
+        Contents.SemanticTag(ListSegmentationSpec.spec_name),
+        Contents.SemanticTag(TableSegmentationSpec.spec_name),
+        Contents.SemanticTag(TableDescriptionSegmentationSpec.spec_name),
+    ),
+)
+
+# -------------------- Arrete segmentation -------------------- #
+
+VisaSegmentationSpec = create_semantic_tag_spec_no_data(
+    spec_name="segmentation:visa",
+    tag_name=SEGMENTATION_TAG_NAME,
+    allowed_contents=(
+        Contents.SemanticTag(TextSpanSegmentationSpec.spec_name),
+        Contents.SemanticTag(ListSegmentationSpec.spec_name),
+    ),
+)
+
+
+MotifSegmentationSpec = create_semantic_tag_spec_no_data(
+    spec_name="segmentation:motifs",
+    tag_name=SEGMENTATION_TAG_NAME,
+    allowed_contents=(
+        Contents.SemanticTag(TextSpanSegmentationSpec.spec_name),
+        Contents.SemanticTag(ListSegmentationSpec.spec_name),
+    ),
 )
 
 
@@ -94,10 +135,67 @@ SectionTitleSegmentationSpec: SemanticTagSpec[SectionTitleSegmentationData] = Se
     spec_name="segmentation:section_title",
     tag_name=SEGMENTATION_TAG_NAME,
     data_model=SectionTitleSegmentationData,
+    allowed_contents=(Contents.SemanticTag(TextSpanSegmentationSpec.spec_name),),
+)
+
+
+AlineaSegmentationSpec: SemanticTagSpec[AlineaData] = SemanticTagSpec(
+    spec_name="segmentation:alinea",
+    tag_name=SEGMENTATION_TAG_NAME,
+    data_model=AlineaData,
+    allowed_contents=(
+        Contents.SemanticTag(TextSpanSegmentationSpec.spec_name),
+        Contents.SemanticTag(ListSegmentationSpec.spec_name),
+        Contents.SemanticTag(TableSegmentationSpec.spec_name),
+        Contents.SemanticTag(TableDescriptionSegmentationSpec.spec_name),
+        Contents.SemanticTag(BlockquoteSegmentationSpec.spec_name),
+        Contents.Tag("img"),
+    ),
 )
 
 
 SectionSegmentationSpec = create_semantic_tag_spec_no_data(
     spec_name="segmentation:section",
     tag_name=SEGMENTATION_TAG_NAME,
+    allowed_contents=(
+        Contents.SemanticTag(SectionTitleSegmentationSpec.spec_name),
+        Contents.SemanticTag(AlineaSegmentationSpec.spec_name),
+        Contents.SemanticTag("segmentation:section"),
+        # Table of contents can be included in appendix sections
+        Contents.SemanticTag(TableOfContentsSpec.spec_name),
+    ),
+)
+
+
+HeaderSegmentationSpec = create_semantic_tag_spec_no_data(
+    spec_name="segmentation:header",
+    tag_name=SEGMENTATION_TAG_NAME,
+    allowed_contents=(
+        Contents.SemanticTag(EmblemSpec.spec_name),
+        Contents.SemanticTag(EntitySpec.spec_name),
+        Contents.SemanticTag(IdentificationSpec.spec_name),
+        Contents.SemanticTag(ArreteTitleSpec.spec_name),
+        Contents.SemanticTag(HonorarySpec.spec_name),
+        Contents.SemanticTag(VisaSegmentationSpec.spec_name),
+        Contents.SemanticTag(MotifSegmentationSpec.spec_name),
+        Contents.SemanticTag(SupplementaryMotifInfoSpec.spec_name),
+        # For lines in the header that havent been recognized as a particular element
+        Contents.SemanticTag(TextSpanSegmentationSpec.spec_name),
+        Contents.SemanticTag(TableOfContentsSpec.spec_name),
+        Contents.Tag("img"),
+    ),
+)
+
+
+MainSegmentationSpec = create_semantic_tag_spec_no_data(
+    spec_name="segmentation:main",
+    tag_name=SEGMENTATION_TAG_NAME,
+    allowed_contents=(Contents.SemanticTag(SectionSegmentationSpec.spec_name),),
+)
+
+
+AppendixSegmentationSpec = create_semantic_tag_spec_no_data(
+    spec_name="segmentation:appendix",
+    tag_name=SEGMENTATION_TAG_NAME,
+    allowed_contents=(Contents.SemanticTag(SectionSegmentationSpec.spec_name),),
 )

--- a/arretify/step_segmentation/testing.py
+++ b/arretify/step_segmentation/testing.py
@@ -24,11 +24,11 @@ from arretify.step_segmentation.semantic_tag_specs import (
 )
 from arretify.types import ProtectedTagOrStr, ProtectedTag
 from arretify.utils.html import is_tag
+from arretify.utils.html_create import make_semantic_tag
 from arretify.utils.html_semantic import (
     get_semantic_tag_data,
     get_semantic_tag_spec,
     is_semantic_tag,
-    make_semantic_tag,
 )
 
 

--- a/arretify/templates/arrete.html
+++ b/arretify/templates/arrete.html
@@ -173,6 +173,5 @@
             }
         </script>
     </head>
-    <body>
-    </body>
+    <body></body>
 </html>

--- a/arretify/utils/html_create.py
+++ b/arretify/utils/html_create.py
@@ -29,6 +29,16 @@ from arretify.types import (
     unprotect_soup,
     unprotect_tag,
 )
+from arretify.utils.html import is_tag, set_attribute
+from arretify.utils.html_semantic import (
+    _SPEC_DATA_ATTR,
+    Contents,
+    SemanticTagSpec,
+    TSemanticTagData,
+    get_semantic_tag_spec,
+    is_semantic_tag,
+    set_semantic_tag_data,
+)
 from arretify.utils.split_merge import (
     split_elements,
     map_splitted_elements,
@@ -39,10 +49,17 @@ from arretify.utils.strings import (
 )
 
 
+_TAGS_ALLOWED_ANYWHERE = {"b", "strong", "i", "em", "u", "br"}
+"""
+These tags are considered as non-structural and can be freely used
+throughout the document.
+"""
+
+
 def wrap_in_tag(
     soup: ProtectedSoup,
-    elements: Sequence[ProtectedTagOrStr],
     tag_name: str,
+    elements: Sequence[ProtectedTagOrStr],
 ) -> list[ProtectedTag]:
     wrapped: list[ProtectedTag] = []
     for element in elements:
@@ -57,17 +74,61 @@ def make_new_tag(
     soup: ProtectedSoup,
     tag_name: str,
     contents: Iterable[ProtectedTagOrStr] | None = None,
+    attrs: dict[str, str] | None = None,
+) -> ProtectedTag:
+    if contents is None:
+        contents = []
+    # If contents is an iterator, convert it to a list to keep the elements
+    else:
+        contents = list(contents)
+    _validate_tag_contents(contents)
+    return _make_new_tag(soup, tag_name, contents=contents, attrs=attrs)
+
+
+def make_semantic_tag(
+    soup: ProtectedSoup,
+    spec: SemanticTagSpec[TSemanticTagData],
+    contents: Iterable[ProtectedTagOrStr] | None = None,
+    data: TSemanticTagData | None = None,
+    attrs: dict[str, str] | None = None,
+) -> ProtectedTag:
+    if contents is None:
+        contents = []
+    # If contents is an iterator, convert it to a list to keep the elements
+    else:
+        contents = list(contents)
+
+    # Create the HTML tag
+    tag = _make_new_tag(soup, spec.tag_name, contents=contents, attrs=attrs)
+
+    return upgrade_to_semantic_tag(tag, spec, data)
+
+
+def upgrade_to_semantic_tag(
+    protected_tag: ProtectedTag,
+    spec: SemanticTagSpec[TSemanticTagData],
+    data: TSemanticTagData | None = None,
+) -> ProtectedTag:
+    _validate_semantic_tag_contents(spec, protected_tag.contents)
+    set_attribute(protected_tag, _SPEC_DATA_ATTR, spec.spec_name)
+    if data is None:
+        data = spec.data_model()
+    set_semantic_tag_data(spec, protected_tag, data)
+    return protected_tag
+
+
+def _make_new_tag(
+    soup: ProtectedSoup,
+    tag_name: str,
+    contents: Iterable[ProtectedTagOrStr],
+    attrs: dict[str, str] | None = None,
 ) -> ProtectedTag:
     # We must be careful not to move elements from one part of the tree to another
     # because that might have unexpected side-effects.
     # For example, if iterating over the children of a tag and moving one of them
     # to a new tag, the list currently being iterated is modified.
     # This is why we work with copies here.
-    cloned_contents: list[ProtectedTagOrStr]
-    if contents is None:
-        cloned_contents = []
-    else:
-        cloned_contents = [copy(element) for element in contents]
+    cloned_contents: list[ProtectedTagOrStr] = [copy(element) for element in contents]
 
     element = unprotect_soup(soup).new_tag(tag_name)
     element.extend(
@@ -81,6 +142,13 @@ def make_new_tag(
             )
         )
     )
+
+    if attrs:
+        for key, value in attrs.items():
+            if key.startswith("data-"):
+                raise ValueError("Attribute data-* are reserved for semantic tag data")
+            element[key] = value
+
     return protect_tag(element)
 
 
@@ -88,6 +156,12 @@ def replace_children(
     protected_tag: ProtectedTag,
     contents: Sequence[ProtectedTagOrStr],
 ) -> ProtectedTag:
+    if is_semantic_tag(protected_tag):
+        spec = get_semantic_tag_spec(protected_tag)
+        _validate_semantic_tag_contents(spec, contents)
+    else:
+        _validate_tag_contents(contents)
+
     tag = unprotect_tag(protected_tag)
     tag.clear()
     # NOTE : `contents` must be a list and not an iterator because
@@ -96,6 +170,67 @@ def replace_children(
     # over `tag.children`, but `tag.clear` removing all of them).
     tag.extend(_unprotect_page_elements(contents))
     return protect_tag(tag)
+
+
+class InvalidContentsError(ValueError):
+    pass
+
+
+def _validate_semantic_tag_contents(
+    spec: SemanticTagSpec, contents: Sequence[ProtectedTagOrStr]
+) -> None:
+    is_str_accepted = any(isinstance(ac, Contents.Str) for ac in spec.allowed_contents)
+    tag_names_accepted = {
+        ac.tag_name for ac in spec.allowed_contents if isinstance(ac, Contents.Tag)
+    }
+    spec_names_accepted = {
+        ac.spec_name for ac in spec.allowed_contents if isinstance(ac, Contents.SemanticTag)
+    }
+
+    for element in contents:
+        if isinstance(element, str):
+            if not is_str_accepted:
+                raise InvalidContentsError(f"String content not accepted in {spec.spec_name}")
+
+        elif is_semantic_tag(element):
+            element_spec = get_semantic_tag_spec(element)
+            if element_spec.is_allowed_anywhere:
+                continue
+
+            if element_spec.spec_name not in spec_names_accepted:
+                raise InvalidContentsError(
+                    f'Semantic tag "{element_spec.spec_name}" not accepted in "{spec.spec_name}"'
+                )
+
+        elif is_tag(element):
+            tag_name = element.name
+            # Allow non-structural tags anywhere, unless the spec forbids all contents.
+            if len(spec.allowed_contents) > 0 and tag_name in _TAGS_ALLOWED_ANYWHERE:
+                continue
+
+            elif tag_name not in tag_names_accepted:
+                raise InvalidContentsError(f"Tag <{tag_name}> not accepted in {spec.spec_name}")
+
+            _validate_tag_contents(element.contents)
+
+        else:
+            raise InvalidContentsError(f"Invalid content type {type(element)} in {spec.spec_name}")
+
+
+def _validate_tag_contents(contents: Sequence[ProtectedTagOrStr]) -> None:
+    """
+    Recursively validates that there is no semantic tag in the subtree.
+    """
+    for element in contents:
+        if is_semantic_tag(element):
+            spec = get_semantic_tag_spec(element)
+            if spec.is_allowed_anywhere:
+                continue
+
+            raise InvalidContentsError(f"Semantic tag {spec.spec_name} not allowed here")
+
+        elif is_tag(element):
+            _validate_tag_contents(element.contents)
 
 
 def _unprotect_page_elements(

--- a/arretify/utils/html_create_test.py
+++ b/arretify/utils/html_create_test.py
@@ -20,7 +20,25 @@ import unittest
 
 from bs4 import BeautifulSoup
 
-from .html_create import make_new_tag
+from arretify.types import ProtectedTagOrStr, protect_soup, unprotect_tag
+from arretify.utils.html_semantic import (
+    Contents,
+    SemanticTagData,
+    SemanticTagSpec,
+    create_semantic_tag_spec_no_data,
+)
+from arretify.utils.html_semantic_test import SemanticTagDataTestCase
+
+from .html_create import (
+    InvalidContentsError,
+    _unprotect_page_elements,
+    _validate_semantic_tag_contents,
+    _validate_tag_contents,
+    make_new_tag,
+    make_semantic_tag,
+    replace_children,
+    upgrade_to_semantic_tag,
+)
 
 
 class TestMakeNewTag(unittest.TestCase):
@@ -46,3 +64,406 @@ class TestMakeNewTag(unittest.TestCase):
         assert len(elements) == 2
         assert str(elements[0]) == "<div><span>bla</span></div>"
         assert str(elements[1]) == "<div><span>blo</span></div>"
+
+    def test_with_contents_iterator(self):
+        # ARRANGE
+        contents = (f"Item {i}" for i in range(3))
+
+        # ACT
+        tag = make_new_tag(self.soup, "ul", contents=contents)
+
+        # ASSERT
+        assert str(tag) == "<ul>Item 0Item 1Item 2</ul>"
+
+    def test_validation_is_performed_on_contents(self):
+        # ARRANGE
+        spec = create_semantic_tag_spec_no_data(
+            spec_name="some_spec",
+            tag_name="div",
+        )
+        contents = [
+            "blabla ",
+            # Semantic tag not allowed in plain tag contents
+            make_semantic_tag(self.soup, spec),
+        ]
+
+        # ACT & ASSERT
+        with self.assertRaises(InvalidContentsError):
+            make_new_tag(self.soup, "p", contents=contents)
+
+    def test_attrs_parameter(self):
+        # ACT
+        tag = make_new_tag(
+            self.soup,
+            "div",
+            contents=["text"],
+            attrs={"class": "my-class", "alt": "some-text"},
+        )
+
+        # ASSERT
+        assert tag.name == "div"
+        assert tag["class"] == "my-class"
+        assert tag["alt"] == "some-text"
+
+    def test_attrs_parameter_with_data_attribute_raises(self):
+        # ACT & ASSERT
+        with self.assertRaises(ValueError):
+            make_new_tag(
+                self.soup,
+                "div",
+                contents=["text"],
+                attrs={"data-spec": "some-spec"},
+            )
+
+
+class TestMakeSemanticTag(SemanticTagDataTestCase):
+
+    def test_creates_tag_with_spec_name(self):
+        # ACT
+        tag = make_semantic_tag(self.soup, self.spec_no_data)
+
+        # ASSERT
+        assert tag.name == "div"
+        assert tag["data-spec"] == "test_no_data"
+
+    def test_creates_tag_with_custom_data(self):
+        # ARRANGE
+        data = self.spec_with_data.data_model(value="hello")
+
+        # ACT
+        tag = make_semantic_tag(self.soup, self.spec_with_data, data=data)
+
+        # ASSERT
+        assert tag["data-value"] == "hello"
+
+    def test_validation_is_performed_on_contents(self):
+        # ARRANGE
+        spec = create_semantic_tag_spec_no_data(
+            spec_name="some_spec",
+            tag_name="div",
+            allowed_contents=(Contents.Str(),),
+        )
+        contents = [
+            "blabla ",
+            # <span> not allowed in spec
+            make_new_tag(self.soup, "span", contents=["text"]),
+        ]
+
+        # ACT & ASSERT
+        with self.assertRaises(InvalidContentsError):
+            make_semantic_tag(self.soup, spec, contents=contents)
+
+    def test_with_contents_iterator(self):
+        # ARRANGE
+        contents = (f"Item {i}" for i in range(3))
+
+        # ACT
+        tag = make_semantic_tag(self.soup, self.spec_no_data, contents=contents)
+
+        # ASSERT
+        assert str(tag) == '<div data-spec="test_no_data">Item 0Item 1Item 2</div>'
+
+    def test_attrs_parameter(self):
+        # ACT
+        tag = make_semantic_tag(
+            self.soup,
+            self.spec_no_data,
+            contents=["text"],
+            attrs={"class": "my-class", "alt": "some-text"},
+        )
+
+        # ASSERT
+        assert tag.name == "div"
+        assert tag["data-spec"] == "test_no_data"
+        assert tag["class"] == "my-class"
+        assert tag["alt"] == "some-text"
+
+
+class TestUpgradeToSemanticTag(unittest.TestCase):
+
+    def setUp(self):
+        self.soup = protect_soup(BeautifulSoup("", "html.parser"))
+
+        self.some_spec = SemanticTagSpec(
+            spec_name="some_spec",
+            tag_name="span",
+            data_model=SemanticTagData,
+            allowed_contents=(Contents.Str(),),
+        )
+
+    def test_upgrades_plain_tag_to_semantic_tag(self):
+        # ARRANGE
+        plain_tag = make_new_tag(self.soup, "span", contents=["text"])
+
+        # ACT
+        semantic_tag = upgrade_to_semantic_tag(plain_tag, self.some_spec)
+
+        # ASSERT
+        assert semantic_tag.name == "span"
+        assert semantic_tag["data-spec"] == "some_spec"
+        assert str(semantic_tag) == '<span data-spec="some_spec">text</span>'
+
+
+class TestValidateSemanticTagContents(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.soup = protect_soup(BeautifulSoup("", "html.parser"))
+
+        self.some_spec = SemanticTagSpec(
+            spec_name="some_spec",
+            tag_name="span",
+            data_model=SemanticTagData,
+        )
+
+    def test_only_str_allowed(self) -> None:
+        # ARRANGE
+        spec_only_str = SemanticTagSpec(
+            spec_name="only_str",
+            tag_name="div",
+            data_model=SemanticTagData,
+            allowed_contents=(Contents.Str(),),
+        )
+
+        str_contents = ["some text"]
+        semantic_tag_contents = [make_semantic_tag(self.soup, self.some_spec)]
+        tag_contents = [make_new_tag(self.soup, "span")]
+
+        # ACT & ASSERT
+        _validate_semantic_tag_contents(spec_only_str, str_contents)
+
+        with self.assertRaises(InvalidContentsError):
+            _validate_semantic_tag_contents(spec_only_str, semantic_tag_contents)
+
+        with self.assertRaises(InvalidContentsError):
+            _validate_semantic_tag_contents(spec_only_str, tag_contents)
+
+    def test_only_specs_allowed(self) -> None:
+        # ARRANGE
+        other_spec = SemanticTagSpec(
+            spec_name="other_spec",
+            tag_name="span",
+            data_model=SemanticTagData,
+        )
+
+        spec_only_specs = SemanticTagSpec(
+            spec_name="only_specs",
+            tag_name="div",
+            data_model=SemanticTagData,
+            allowed_contents=(Contents.SemanticTag(spec_name=self.some_spec.spec_name),),
+        )
+
+        allowed_semantic_tag_contents = [make_semantic_tag(self.soup, self.some_spec)]
+        other_semantic_tag_contents = [make_semantic_tag(self.soup, other_spec)]
+        str_contents = ["some text"]
+        tag_contents = [make_new_tag(self.soup, "span")]
+
+        # ACT & ASSERT
+        _validate_semantic_tag_contents(spec_only_specs, allowed_semantic_tag_contents)
+
+        with self.assertRaises(InvalidContentsError):
+            _validate_semantic_tag_contents(spec_only_specs, str_contents)
+
+        with self.assertRaises(InvalidContentsError):
+            _validate_semantic_tag_contents(spec_only_specs, other_semantic_tag_contents)
+
+        with self.assertRaises(InvalidContentsError):
+            _validate_semantic_tag_contents(spec_only_specs, tag_contents)
+
+    def test_only_tags_allowed(self) -> None:
+        # ARRANGE
+        spec_only_tags = SemanticTagSpec(
+            spec_name="only_tags",
+            tag_name="div",
+            data_model=SemanticTagData,
+            allowed_contents=(Contents.Tag(tag_name="span"), Contents.Tag(tag_name="ul")),
+        )
+
+        allowed_tag_contents = [make_new_tag(self.soup, "span")]
+        str_contents = ["some text"]
+        semantic_tag_contents = [make_semantic_tag(self.soup, self.some_spec)]
+        wrong_tag_contents = [make_new_tag(self.soup, "ol")]
+
+        # ACT & ASSERT
+        _validate_semantic_tag_contents(spec_only_tags, allowed_tag_contents)
+
+        with self.assertRaises(InvalidContentsError):
+            _validate_semantic_tag_contents(spec_only_tags, str_contents)
+
+        with self.assertRaises(InvalidContentsError):
+            _validate_semantic_tag_contents(spec_only_tags, semantic_tag_contents)
+
+        with self.assertRaises(InvalidContentsError):
+            _validate_semantic_tag_contents(spec_only_tags, wrong_tag_contents)
+
+    def test_nothing_allowed(self) -> None:
+        # ARRANGE
+        spec_nothing = SemanticTagSpec(
+            spec_name="nothing",
+            tag_name="div",
+            data_model=SemanticTagData,
+            allowed_contents=(),
+        )
+
+        empty_contents: list = []
+        str_contents = ["text"]
+        semantic_tag_contents = [make_semantic_tag(self.soup, self.some_spec)]
+        tag_contents = [make_new_tag(self.soup, "span")]
+
+        # ACT & ASSERT
+        _validate_semantic_tag_contents(spec_nothing, empty_contents)
+
+        with self.assertRaises(InvalidContentsError):
+            _validate_semantic_tag_contents(spec_nothing, str_contents)
+
+        with self.assertRaises(InvalidContentsError):
+            _validate_semantic_tag_contents(spec_nothing, semantic_tag_contents)
+
+        with self.assertRaises(InvalidContentsError):
+            _validate_semantic_tag_contents(spec_nothing, tag_contents)
+
+    def test_everything_allowed(self) -> None:
+        # ARRANGE
+        spec_everything = SemanticTagSpec(
+            spec_name="everything",
+            tag_name="div",
+            data_model=SemanticTagData,
+            allowed_contents=(
+                Contents.Str(),
+                Contents.SemanticTag(spec_name=self.some_spec.spec_name),
+                Contents.Tag(tag_name="span"),
+            ),
+        )
+
+        str_contents = ["text"]
+        allowed_semantic_tag_contents = [make_semantic_tag(self.soup, self.some_spec)]
+        allowed_tag_contents = [make_new_tag(self.soup, "span")]
+        mixed_contents: list[ProtectedTagOrStr] = [
+            "text",
+            make_semantic_tag(self.soup, self.some_spec),
+            make_new_tag(self.soup, "span"),
+        ]
+
+        # ACT & ASSERT
+        _validate_semantic_tag_contents(spec_everything, str_contents)
+        _validate_semantic_tag_contents(spec_everything, allowed_semantic_tag_contents)
+        _validate_semantic_tag_contents(spec_everything, allowed_tag_contents)
+        _validate_semantic_tag_contents(spec_everything, mixed_contents)
+
+    def test_is_allowed_anywhere(self) -> None:
+        # ARRANGE
+        spec_is_allowed_anywhere = SemanticTagSpec(
+            spec_name="is_allowed_anywhere",
+            tag_name="div",
+            data_model=SemanticTagData,
+            allowed_contents=(),
+            is_allowed_anywhere=True,
+        )
+
+        semantic_tag_contents = [make_semantic_tag(self.soup, spec_is_allowed_anywhere)]
+
+        # ACT & ASSERT
+        _validate_semantic_tag_contents(self.some_spec, semantic_tag_contents)
+
+    def test_tags_allowed_anywhere(self) -> None:
+        # ARRANGE
+        spec_only_str = SemanticTagSpec(
+            spec_name="only_str",
+            tag_name="div",
+            data_model=SemanticTagData,
+            allowed_contents=(Contents.Str(),),
+        )
+
+        contents = [
+            make_new_tag(self.soup, "b"),
+            make_new_tag(self.soup, "i"),
+            make_new_tag(self.soup, "u"),
+            make_new_tag(self.soup, "strong"),
+            make_new_tag(self.soup, "em"),
+            make_new_tag(self.soup, "br"),
+        ]
+
+        # ACT & ASSERT
+        _validate_semantic_tag_contents(spec_only_str, contents)
+
+    def test_tags_allowed_anywhere_but_no_contents_allowed(self) -> None:
+        # ARRANGE
+        spec_nothing = SemanticTagSpec(
+            spec_name="nothing",
+            tag_name="div",
+            data_model=SemanticTagData,
+            allowed_contents=(),
+        )
+
+        contents = [
+            make_new_tag(self.soup, "b"),
+        ]
+
+        # ACT & ASSERT
+        with self.assertRaises(InvalidContentsError):
+            _validate_semantic_tag_contents(spec_nothing, contents)
+
+
+class TestValidateTagContents(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.soup = protect_soup(BeautifulSoup("", "html.parser"))
+
+        self.some_spec = SemanticTagSpec(
+            spec_name="some_spec",
+            tag_name="span",
+            data_model=SemanticTagData,
+        )
+
+    def test_valid_plain_tags_and_strings(self) -> None:
+        # ARRANGE
+        div_tag = make_new_tag(self.soup, "div", contents=["text"])
+        span_tag = make_new_tag(self.soup, "span", contents=["emphasized"])
+        nested_tag = make_new_tag(self.soup, "p")
+        nested_tag = replace_children(nested_tag, [span_tag, " more text"])
+
+        # ACT & ASSERT
+        _validate_tag_contents(["text"])
+        _validate_tag_contents([div_tag, span_tag])
+        _validate_tag_contents([div_tag, "text", span_tag])
+        _validate_tag_contents([nested_tag])
+
+    def test_invalid_semantic_tag_in_contents(self) -> None:
+        # ARRANGE
+        semantic_tag = make_semantic_tag(self.soup, self.some_spec)
+
+        # ACT & ASSERT
+        with self.assertRaises(InvalidContentsError):
+            _validate_tag_contents([semantic_tag])
+
+    def test_invalid_nested_semantic_tag(self) -> None:
+        # ARRANGE
+        semantic_tag = make_semantic_tag(self.soup, self.some_spec)
+        div_tag = make_new_tag(self.soup, "div")
+        # Bypass validation by directly manipulating the tag
+        unprotect_tag(div_tag).extend(_unprotect_page_elements([semantic_tag]))
+
+        # ACT & ASSERT
+        with self.assertRaises(InvalidContentsError):
+            _validate_tag_contents(div_tag.contents)
+
+    def test_empty_contents(self) -> None:
+        # ARRANGE
+        empty_contents: list = []
+
+        # ACT & ASSERT
+        _validate_tag_contents(empty_contents)
+
+    def test_is_allowed_anywhere(self) -> None:
+        # ARRANGE
+        spec_is_allowed_anywhere = SemanticTagSpec(
+            spec_name="is_allowed_anywhere",
+            tag_name="div",
+            data_model=SemanticTagData,
+            allowed_contents=(),
+            is_allowed_anywhere=True,
+        )
+
+        semantic_tag = make_semantic_tag(self.soup, spec_is_allowed_anywhere)
+
+        # ACT & ASSERT
+        _validate_tag_contents([semantic_tag])

--- a/arretify/utils/html_semantic.py
+++ b/arretify/utils/html_semantic.py
@@ -18,7 +18,7 @@
 #
 from dataclasses import dataclass
 from enum import Enum
-from typing import Iterable, Sequence, TypeGuard, Annotated, TypeVar, Type, Generic, Union, cast
+from typing import Sequence, TypeGuard, Annotated, TypeVar, Type, Generic, cast
 
 from pydantic import (
     BaseModel,
@@ -30,9 +30,8 @@ from pydantic import (
 from pydantic.functional_serializers import PlainSerializer
 
 from arretify.errors import ErrorCodes
-from arretify.types import ProtectedTagOrStr, ProtectedSoup, ProtectedTag
+from arretify.types import ProtectedTagOrStr, ProtectedTag
 from arretify.utils.html import GROUP_ID_ATTR, TAG_ID_ATTR, is_tag, set_attribute
-from arretify.utils.html_create import make_new_tag
 
 
 _SPEC_DATA_ATTR = "data-spec"
@@ -109,7 +108,23 @@ IntList = Annotated[
 
 # -------------------- Base models -------------------- #
 TSemanticTagData = TypeVar("TSemanticTagData", bound="SemanticTagData")
-ContentsSpecs = tuple[Union[type[str], str, "SemanticTagSpec"], ...]
+
+
+class Contents:
+    @dataclass(frozen=True, eq=True)
+    class Str:
+        pass
+
+    @dataclass(frozen=True, eq=True)
+    class Tag:
+        tag_name: str
+
+    @dataclass(frozen=True, eq=True)
+    class SemanticTag:
+        spec_name: str
+
+    Any = tuple[Str | Tag | SemanticTag, ...]
+
 
 _REGISTRY: dict[str, "SemanticTagSpec"] = {}
 
@@ -155,7 +170,12 @@ class SemanticTagSpec(Generic[TSemanticTagData]):
     spec_name: str
     tag_name: str
     data_model: Type[TSemanticTagData]
-    contents_specs: ContentsSpecs = tuple()
+    allowed_contents: Contents.Any = tuple()
+    is_allowed_anywhere: bool = False
+    """
+    Whether this semantic tag can appear anywhere in the document.
+    If True, this tag is not subject to content restrictions.
+    """
 
     def __post_init__(self):
         _REGISTRY[self.spec_name] = self
@@ -164,6 +184,8 @@ class SemanticTagSpec(Generic[TSemanticTagData]):
 def create_semantic_tag_spec_no_data(
     spec_name: str,
     tag_name: str,
+    allowed_contents: Contents.Any = tuple(),
+    is_allowed_anywhere: bool = False,
 ) -> SemanticTagSpec[SemanticTagData]:
     """
     Create a SemanticTagSpec with the default SemanticTagData model.
@@ -172,6 +194,8 @@ def create_semantic_tag_spec_no_data(
         spec_name=spec_name,
         tag_name=tag_name,
         data_model=SemanticTagData,
+        allowed_contents=allowed_contents,
+        is_allowed_anywhere=is_allowed_anywhere,
     )
 
 
@@ -204,32 +228,6 @@ def is_semantic_tag(
 
 def css_selector(spec: SemanticTagSpec[TSemanticTagData]) -> str:
     return f'[{_SPEC_DATA_ATTR}="{spec.spec_name}"]'
-
-
-def make_semantic_tag(
-    soup: ProtectedSoup,
-    spec: SemanticTagSpec[TSemanticTagData],
-    contents: Iterable[ProtectedTagOrStr] | None = None,
-    data: TSemanticTagData | None = None,
-) -> ProtectedTag:
-    if contents is None:
-        contents = []
-
-    # Validate contents
-    # _validate_contents(spec, list(contents))
-
-    # Create data instance if not provided
-    if data is None:
-        data = spec.data_model()
-
-    # Create the HTML tag
-    tag = make_new_tag(soup, spec.tag_name, contents=contents)
-    set_attribute(tag, _SPEC_DATA_ATTR, spec.spec_name)
-
-    # Set data attributes from the validated data instance
-    set_semantic_tag_data(spec, tag, data)
-
-    return tag
 
 
 def get_semantic_tag_spec(tag: ProtectedTag) -> SemanticTagSpec:

--- a/arretify/utils/html_semantic_test.py
+++ b/arretify/utils/html_semantic_test.py
@@ -27,6 +27,7 @@ from arretify.utils.html import set_attribute
 from arretify.utils.html_create import make_new_tag
 
 from .html_semantic import (
+    Contents,
     IntList,
     SemanticTagData,
     SemanticTagSpec,
@@ -36,7 +37,6 @@ from .html_semantic import (
     StrList,
     enum_serializer,
     update_data,
-    make_semantic_tag,
     set_semantic_tag_data,
     get_semantic_tag_data,
     enum_list_parser,
@@ -51,6 +51,7 @@ class SemanticTagDataTestCase(unittest.TestCase):
         self.spec_no_data = create_semantic_tag_spec_no_data(
             spec_name="test_no_data",
             tag_name="div",
+            allowed_contents=(Contents.Str(),),
         )
 
         class CustomData(SemanticTagData):
@@ -82,27 +83,6 @@ class TestCssSelector(unittest.TestCase):
 
         # ASSERT
         assert selector == '[data-spec="test_spec"]'
-
-
-class TestMakeSemanticTag(SemanticTagDataTestCase):
-
-    def test_creates_tag_with_spec_name(self):
-        # ACT
-        tag = make_semantic_tag(self.soup, self.spec_no_data)
-
-        # ASSERT
-        assert tag.name == "div"
-        assert tag["data-spec"] == "test_no_data"
-
-    def test_creates_tag_with_custom_data(self):
-        # ARRANGE
-        data = self.spec_with_data.data_model(value="hello")
-
-        # ACT
-        tag = make_semantic_tag(self.soup, self.spec_with_data, data=data)
-
-        # ASSERT
-        assert tag["data-value"] == "hello"
 
 
 class TestIsSemanticTag(unittest.TestCase):

--- a/arretify/utils/markdown_parsing.py
+++ b/arretify/utils/markdown_parsing.py
@@ -24,8 +24,7 @@ import markdown
 
 from arretify.errors import ErrorCodes
 from arretify.types import ProtectedTag, protect_soup
-from arretify.utils.html_create import make_new_tag
-from arretify.utils.html_semantic import make_semantic_tag
+from arretify.utils.html_create import make_new_tag, make_semantic_tag
 from arretify.semantic_tag_specs import ErrorSpec
 from arretify.regex_utils import PatternProxy, repeated_with_separator
 

--- a/arretify/utils/split_merge.py
+++ b/arretify/utils/split_merge.py
@@ -164,6 +164,33 @@ def flat_map_splitted_elements(
             yield from splitted_element.value
 
 
+def split_and_map_elements(
+    elements: Sequence[T1],
+    splitter: Splitter[T1, T2],
+    map_func: Callable[[T2], T3],
+) -> list[T1 | T3]:
+    """
+    Convenience function that chains `split_elements` and `map_splitted_elements`.
+    Splits the input list using the provided splitter,
+    maps the matched elements using the provided map function,
+    and returns a new list with the mapped elements.
+
+    For example :
+
+    >>> some_numbers = [1, 3, 11, 10, 6, 23]
+    >>> def multiple_of_3(elements: Sequence[int]) -> RawSplit[int, int] | None:
+    ...     for i, element in enumerate(elements):
+    ...         if element % 3 == 0:
+    ...             return elements[:i], element, elements[i + 1:]
+    ...     return None
+    >>> def map_func(n: int) -> str:
+    ...     return f"Number {n} is multiple of 3"
+    >>> remap_elements(some_numbers, multiple_of_3, map_func)
+    [1, 'Number 3 is multiple of 3', 11, 10, 'Number 6 is multiple of 3', 23]
+    """  # noqa: E501
+    return map_splitted_elements(split_elements(elements, splitter), map_func)
+
+
 @iter_func_to_list
 def merge_splitted_elements(
     splitted_list: Sequence[SplittedElement[T1, Sequence[T1]]],

--- a/arretify/utils/split_merge_test.py
+++ b/arretify/utils/split_merge_test.py
@@ -24,6 +24,7 @@ from .split_merge import (
     make_while_splitter,
     negate,
     split_before_match,
+    split_and_map_elements,
     SplitMatch,
     SplitNotAMatch,
 )
@@ -168,6 +169,40 @@ class TestSplitElements(unittest.TestCase):
             SplitMatch(elements[2:3]),
         ]
         assert result == expected
+
+
+class TestSplitAndMapElements(unittest.TestCase):
+
+    def test_split_and_map(self):
+        # Arrange
+        some_numbers = [1, 3, 11, 10, 6, 23]
+
+        def multiple_of_3(elements):
+            for i, element in enumerate(elements):
+                if element % 3 == 0:
+                    return elements[:i], element, elements[i + 1 :]
+            return None
+
+        def map_func(n):
+            return f"Number {n} is multiple of 3"
+
+        # Act
+        result = list(
+            split_and_map_elements(
+                some_numbers,
+                multiple_of_3,
+                map_func,
+            )
+        )
+        # Assert
+        assert result == [
+            1,
+            "Number 3 is multiple of 3",
+            11,
+            10,
+            "Number 6 is multiple of 3",
+            23,
+        ]
 
 
 class TestMakeSingleLineSplitter(unittest.TestCase):

--- a/examples/arretes_html/arrete_bilan_ars_mistral.html
+++ b/examples/arretes_html/arrete_bilan_ars_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arrete_chambre_agriculture_mistral.html
+++ b/examples/arretes_html/arrete_chambre_agriculture_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arrete_circulation_mistral.html
+++ b/examples/arretes_html/arrete_circulation_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arrete_nomination_mistral.html
+++ b/examples/arretes_html/arrete_nomination_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arrete_ppr_mistral.html
+++ b/examples/arretes_html/arrete_ppr_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arrete_rectorat_mistral.html
+++ b/examples/arretes_html/arrete_rectorat_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arrete_sentiers_randonnee_mistral.html
+++ b/examples/arretes_html/arrete_sentiers_randonnee_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arretes_icpe/0003013459/2020-04-20_AP_mistral.html
+++ b/examples/arretes_html/arretes_icpe/0003013459/2020-04-20_AP_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arretes_icpe/0003013459/2021-09-24_AP_mistral.html
+++ b/examples/arretes_html/arretes_icpe/0003013459/2021-09-24_AP_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arretes_icpe/0003013459/2023-02-22_APC_mistral.html
+++ b/examples/arretes_html/arretes_icpe/0003013459/2023-02-22_APC_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arretes_icpe/0005302394/2008-12-10_AP_mistral.html
+++ b/examples/arretes_html/arretes_icpe/0005302394/2008-12-10_AP_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arretes_icpe/0005302394/2009-12-18_AP_mistral.html
+++ b/examples/arretes_html/arretes_icpe/0005302394/2009-12-18_AP_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arretes_icpe/0005302394/2010-12-24_AP_mistral.html
+++ b/examples/arretes_html/arretes_icpe/0005302394/2010-12-24_AP_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arretes_icpe/0005302394/2012-04-03_AP_mistral.html
+++ b/examples/arretes_html/arretes_icpe/0005302394/2012-04-03_AP_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arretes_icpe/0005302394/2012-12-07_AP_mistral.html
+++ b/examples/arretes_html/arretes_icpe/0005302394/2012-12-07_AP_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arretes_icpe/0005302394/2020-12-22_AP_mistral.html
+++ b/examples/arretes_html/arretes_icpe/0005302394/2020-12-22_AP_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arretes_icpe/0005800425/2003-09-09_AP_mistral.html
+++ b/examples/arretes_html/arretes_icpe/0005800425/2003-09-09_AP_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arretes_icpe/0005800425/2005-11-08_AP_mistral.html
+++ b/examples/arretes_html/arretes_icpe/0005800425/2005-11-08_AP_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arretes_icpe/0005800425/2007-04-19_AP_mistral.html
+++ b/examples/arretes_html/arretes_icpe/0005800425/2007-04-19_AP_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arretes_icpe/0005800425/2010-03-29_AP_mistral.html
+++ b/examples/arretes_html/arretes_icpe/0005800425/2010-03-29_AP_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arretes_icpe/0005800425/2012-09-03_AP_mistral.html
+++ b/examples/arretes_html/arretes_icpe/0005800425/2012-09-03_AP_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arretes_icpe/0005800425/2025-02-24_APC_mistral.html
+++ b/examples/arretes_html/arretes_icpe/0005800425/2025-02-24_APC_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arretes_icpe/0005804239/2009-12-08_AP_mistral.html
+++ b/examples/arretes_html/arretes_icpe/0005804239/2009-12-08_AP_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arretes_icpe/0005804239/2012-04-02_AP_mistral.html
+++ b/examples/arretes_html/arretes_icpe/0005804239/2012-04-02_AP_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arretes_icpe/0005804239/2013-07-19_Autre_mistral.html
+++ b/examples/arretes_html/arretes_icpe/0005804239/2013-07-19_Autre_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arretes_icpe/0005804239/2014-01-09_APC_mistral.html
+++ b/examples/arretes_html/arretes_icpe/0005804239/2014-01-09_APC_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arretes_icpe/0005804239/2014-12-11_APC_mistral.html
+++ b/examples/arretes_html/arretes_icpe/0005804239/2014-12-11_APC_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arretes_icpe/0005804239/2020-04-30_APC_mistral.html
+++ b/examples/arretes_html/arretes_icpe/0005804239/2020-04-30_APC_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arretes_icpe/0005804239/2023-12-04_APC_mistral.html
+++ b/examples/arretes_html/arretes_icpe/0005804239/2023-12-04_APC_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>

--- a/examples/arretes_html/arretes_icpe/0005804239/2024-09-27_APC_mistral.html
+++ b/examples/arretes_html/arretes_icpe/0005804239/2024-09-27_APC_mistral.html
@@ -173,7 +173,7 @@
             }
   </script>
  </head>
- <body>
+ <body data-spec="arrete">
   <header data-spec="header">
    <a data-page_index="0" data-spec="page_separator">
    </a>


### PR DESCRIPTION
Ajout d'un système de validation pour le contenu des tags, afin de forcer une structure de balises sémantiques bien définie et explicite pour les arrêtés. Les fichiers à regarder en particulier sont :

- arretify/utils/html_create.py
- arretify/utils/html_semantic.py
- arretify\step_segmentation\semantic_tag_specs.py
- arretify\semantic_tag_specs.py