### PR TITLE
T479 spec tag hierarchy [part3]

### DIFF
--- a/arretify/step_segmentation/__step__.py
+++ b/arretify/step_segmentation/__step__.py
@@ -19,7 +19,8 @@
 from arretify.semantic_tag_specs import ArreteSpec
 from arretify.types import DocumentContext
 from arretify.utils.html_create import replace_children, upgrade_to_semantic_tag
-from .parse_arrete import parse_arrete, render_arrete
+from .parse_arrete import parse_arrete
+from .render_contents import render_contents
 
 
 def step_segmentation(document_context: DocumentContext) -> DocumentContext:
@@ -34,7 +35,7 @@ def step_segmentation(document_context: DocumentContext) -> DocumentContext:
     upgrade_to_semantic_tag(body, ArreteSpec)
     replace_children(
         body,
-        render_arrete(
+        render_contents(
             document_context,
             parse_arrete(document_context, pages),
         ),

--- a/arretify/step_segmentation/basic_elements.py
+++ b/arretify/step_segmentation/basic_elements.py
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import List, Sequence, Tuple, Iterator
+from typing import Sequence, Tuple, Iterator
 import logging
 
 from arretify.parsing_utils.patterns import is_continuing_sentence
@@ -29,24 +29,20 @@ from arretify.step_segmentation.semantic_tag_specs import (
 )
 from arretify.types import DocumentContext, ProtectedTagOrStr, ProtectedTag
 from arretify.utils.functional import iter_func_to_list, chain_functions
-from arretify.utils.html import is_tag
 from arretify.utils.html_semantic import (
     SemanticTagData,
     get_semantic_tag_data,
     is_semantic_tag,
 )
 from arretify.utils.html_create import (
-    make_new_tag,
     make_semantic_tag,
     replace_children,
 )
 from arretify.utils.markdown_parsing import (
     is_table_description,
-    TABLE_HEADER_SEPARATOR_PATTERN,
     TABLE_LINE_PATTERN,
     IMAGE_PATTERN,
     LIST_PATTERN,
-    parse_markdown_table,
     parse_markdown_image,
 )
 from arretify.regex_utils import (
@@ -59,13 +55,8 @@ from arretify.regex_utils import (
 from arretify.errors import ErrorCodes
 from arretify.semantic_tag_specs import (
     ErrorSpec,
-    PageSeparatorSpec,
-    PageFooterSpec,
-    TableOfContentsSpec,
     AddressSpec,
 )
-from arretify.regex_utils import split_string_with_regex
-from arretify.regex_utils import map_matches
 from arretify.utils.split_merge import (
     Probe,
     RawSplit,
@@ -168,80 +159,10 @@ def _table_splitter(
         return None
 
 
-def render_table(
-    context: DocumentContext,
-    tag: ProtectedTag,
-) -> ProtectedTag:
-    pile: list[str] = []
-    has_table_header = False
-    transparent_tags: list[Tuple[int, ProtectedTag]] = []
-    for element in tag.contents:
-        if is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec]):
-            element_str = get_string(element)
-            pile.append(element_str)
-            if bool(TABLE_HEADER_SEPARATOR_PATTERN.match(element_str)):
-                has_table_header = True
-        elif is_semantic_tag(element, spec_in=[PageSeparatorSpec]):
-            table_tag = parse_markdown_table(pile)
-            # Get the right table row for inserting the transparent tag.
-            # If the table has a header, the `pile` contains a header
-            # separation line (e.g. "|---|---|---|"), which is not
-            # counting as a row in the final html table tag.
-            row_index = len(pile) - 1 - int(has_table_header)
-            transparent_tags.append((row_index, element))
-        else:
-            raise ValueError(f"Unexpected element type {type(element)} in table rendering.")
-
-    table_tag = parse_markdown_table(pile)
-
-    # Insert transparent tags in their corresponding table rows.
-    table_rows = table_tag.select("tr")
-    for row_index, transparent_tag in transparent_tags:
-        if row_index < len(table_rows) and row_index >= 0:
-            last_cell_tag = table_rows[row_index].select("td, th")[-1]
-            replace_children(last_cell_tag, last_cell_tag.contents + [transparent_tag])
-        else:
-            raise ValueError(f"Invalid index {row_index} in table rendering. ")
-
-    return table_tag
-
-
-def render_table_description(
-    context: DocumentContext,
-    tag: ProtectedTag,
-) -> Iterator[ProtectedTagOrStr]:
-    for element in tag.contents:
-        if is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec]):
-            yield make_new_tag(context.protected_soup, "br")
-            yield get_string(element)
-        elif is_semantic_tag(element, spec_in=[PageSeparatorSpec]):
-            yield element
-        else:
-            raise ValueError(
-                f"Unexpected element type {type(element)} in table description rendering."
-            )
-
-
 # -------------------- Lists -------------------- #
-LEADING_WHITESPACES_PATTERN = PatternProxy(r"^\s+")
-"""Detect leading whitespaces."""
-
 _is_list_element = make_probe_from_pattern_proxy(LIST_PATTERN)
 _is_list_start = pick_text_spans(_is_list_element)
 _is_list_continuation = pick_if_transparent_tag_followed_by_match(pick_text_spans(_is_list_element))
-
-
-def _list_indentation(line: str) -> int:
-    list_match = LIST_PATTERN.match(line)
-    if not list_match:
-        raise ValueError("Expected line to be a list element")
-    indentation = list_match.group("indentation")
-    assert indentation is not None
-    return len(indentation)
-
-
-def _clean_leading_whitespaces(line: str) -> str:
-    return LEADING_WHITESPACES_PATTERN.sub("", line)
 
 
 def _make_list_splitter(
@@ -313,58 +234,6 @@ def parse_lists(
         ),
         lambda pile: make_semantic_tag(context.protected_soup, ListSegmentationSpec, contents=pile),
     )
-
-
-def render_list(
-    context: DocumentContext,
-    tag: ProtectedTag,
-) -> ProtectedTag:
-    elements, ul = _render_list(context, tag.contents)
-    assert len(elements) == 0, "Expected all lines to be consumed in list rendering"
-    return ul
-
-
-def _render_list(
-    context: DocumentContext,
-    elements_: Sequence[ProtectedTagOrStr],
-) -> Tuple[list[ProtectedTagOrStr], ProtectedTag]:
-    elements = list(elements_)
-    list_pile: list[ProtectedTag] = []
-    element = elements[0]
-    ref_indentation = _list_indentation(get_string(element))
-
-    while elements:
-        element = elements[0]
-
-        if is_semantic_tag(element, spec_in=[PageSeparatorSpec]):
-            list_pile[-1] = replace_children(list_pile[-1], list_pile[-1].contents + [element])
-            elements.pop(0)
-
-        elif is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec]):
-            current_indentation = _list_indentation(get_string(element))
-
-            if current_indentation == ref_indentation:
-                li_contents = list(render_text_span(context, element))
-                if isinstance(li_contents[0], str):
-                    li_contents[0] = _clean_leading_whitespaces(li_contents[0])
-                list_pile.append(make_new_tag(context.protected_soup, "li", contents=li_contents))
-                elements.pop(0)
-
-            elif current_indentation > ref_indentation:
-                elements, nested_ul = _render_list(context, elements)
-                list_pile[-1] = replace_children(
-                    list_pile[-1], list_pile[-1].contents + [nested_ul]
-                )
-
-            # If the indentation is less than the reference indentation,
-            # we exit the function and go up one level.
-            else:
-                break
-
-        else:
-            raise ValueError(f"Unexpected element {element} in list rendering.")
-
-    return elements, make_new_tag(context.protected_soup, "ul", contents=list_pile)
 
 
 # -------------------- Blockquotes -------------------- #
@@ -492,28 +361,6 @@ def _get_last_str(
     raise ValueError("No str found.")
 
 
-def render_blockquote(
-    context: DocumentContext,
-    tag: ProtectedTag,
-) -> ProtectedTag:
-    contents: List[ProtectedTagOrStr] = []
-    for element in list(tag.contents):
-        if is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec]):
-            contents.append(
-                make_new_tag(
-                    context.protected_soup,
-                    "p",
-                    # TODO : should be parsed like other tags, instead of being
-                    # rendered here on the fly. This would also make parsing blockquote easier.
-                    contents=render_inline_quotes(context, get_string(element)),
-                )
-            )
-        elif is_semantic_tag(element):
-            contents.extend(render_basic_elements(context, element))
-
-    return make_new_tag(context.protected_soup, "blockquote", contents=contents)
-
-
 # -------------------- Images -------------------- #
 _is_image = make_probe_from_pattern_proxy(IMAGE_PATTERN)
 
@@ -606,58 +453,3 @@ def _address_splitter(
         street_number + street_name_and_remainder[0 : len(candidate)],
         after_elements,
     )
-
-
-# -------------------- Misc -------------------- #
-INLINE_QUOTE_PATTERN = PatternProxy(r'"(?P<quoted>[^"]+)"')
-"""Detect if a sentence has inline quotes."""
-
-
-def render_inline_quotes(context: DocumentContext, string: str) -> Iterator[ProtectedTagOrStr]:
-    return map_matches(
-        split_string_with_regex(INLINE_QUOTE_PATTERN, string),
-        lambda inline_quote_match: make_new_tag(
-            context.protected_soup,
-            "q",
-            contents=[str(inline_quote_match.group("quoted"))],
-        ),
-    )
-
-
-@iter_func_to_list
-def render_text_span(
-    context: DocumentContext,
-    tag: ProtectedTag,
-) -> Iterator[ProtectedTagOrStr]:
-    for i, element in enumerate(tag.contents):
-        if isinstance(element, str):
-            # If this is not the last element, we add a space as separator.
-            yield element + " " * int(i < len(tag.contents) - 1)
-        elif is_semantic_tag(element, spec_in=[PageSeparatorSpec, AddressSpec]):
-            yield element
-        else:
-            raise ValueError(f"Unexpected element type {type(element)} in text span rendering.")
-
-
-def render_basic_elements(
-    context: DocumentContext,
-    tag: ProtectedTag,
-) -> Iterator[ProtectedTagOrStr]:
-    if is_semantic_tag(tag, spec_in=[ListSegmentationSpec]):
-        yield render_list(context, tag)
-    elif is_semantic_tag(tag, spec_in=[TableSegmentationSpec]):
-        yield render_table(context, tag)
-    elif is_semantic_tag(tag, spec_in=[TableDescriptionSegmentationSpec]):
-        yield from render_table_description(context, tag)
-    elif is_semantic_tag(tag, spec_in=[BlockquoteSegmentationSpec]):
-        yield render_blockquote(context, tag)
-    elif is_semantic_tag(
-        tag, spec_in=[PageFooterSpec, PageSeparatorSpec, TableOfContentsSpec, ErrorSpec]
-    ):
-        yield tag
-    elif is_semantic_tag(tag, spec_in=[TextSpanSegmentationSpec]):
-        yield from render_text_span(context, tag)
-    elif is_tag(tag, tag_name_in=["img"]):
-        yield tag
-    else:
-        raise ValueError(f"Unknown tag type '{tag.name}' in render_basic_elements.")

--- a/arretify/step_segmentation/basic_elements_test.py
+++ b/arretify/step_segmentation/basic_elements_test.py
@@ -38,23 +38,15 @@ from arretify.utils.html_semantic import (
 )
 
 from .basic_elements import (
-    _list_indentation,
     parse_lists,
     parse_tables,
     parse_blockquotes,
     parse_images,
     parse_addresses,
-    render_inline_quotes,
-    render_table,
-    render_table_description,
-    render_list,
-    render_blockquote,
 )
 from .testing import assert_elements_equal, make_text_spans
 from arretify.utils.testing import (
     create_document_context,
-    normalized_html_str,
-    assert_html_list_equal,
 )
 from arretify.law_data.french_addresses import ALL_STREET_NAMES
 
@@ -69,40 +61,6 @@ class BaseTestCase(unittest.TestCase):
     def setUp(self):
         self.context = create_document_context()
         self.soup = self.context.protected_soup
-
-
-class TestListIndentation(BaseTestCase):
-
-    def test_correct_indentation(self):
-        # Arrange
-        line = "    - Item in list"
-
-        # Act
-        result = _list_indentation(line)
-
-        # Assert
-        assert result == 4, "Should return the correct indentation level"
-
-    def test_no_indentation(self):
-        # Arrange
-        line = "- Item in list"
-
-        # Act
-        result = _list_indentation(line)
-
-        # Assert
-        assert result == 0, "Should return zero for no indentation"
-
-    def test_not_a_list_element(self):
-        # Arrange
-        line = "This is not a list item"
-
-        # Act / Assert
-        with self.assertRaises(ValueError) as context:
-            _list_indentation(line)
-        assert (
-            str(context.exception) == "Expected line to be a list element"
-        ), "Should raise ValueError for non-list lines"
 
 
 class TestParseTables(BaseTestCase):
@@ -476,198 +434,6 @@ class TestParseBlockQuote(BaseTestCase):
         )
 
 
-class TestParseInlineQuotes(BaseTestCase):
-
-    def test_inline_quote(self):
-        # Arrange
-        line = 'bla bla "haha" bli bli'
-
-        # Act
-        result = render_inline_quotes(self.context, line)
-
-        # Assert
-        assert [str(element) for element in result] == [
-            "bla bla ",
-            "<q>haha</q>",
-            " bli bli",
-        ]
-
-
-class TestRenderTable(BaseTestCase):
-
-    def test_render_table_with_page_separators(self):
-        # Arrange
-        tag = make_semantic_tag(
-            self.soup,
-            TableSegmentationSpec,
-            contents=[
-                *make_text_spans(self.soup, "| Column 1 | Column 2 |", "|----------|----------|"),
-                make_semantic_tag(
-                    self.soup, PageSeparatorSpec, data=PageSeparatorData(page_index=1)
-                ),
-                *make_text_spans(
-                    self.soup,
-                    "| Row 1    | Data 1   |",
-                ),
-                make_semantic_tag(
-                    self.soup, PageSeparatorSpec, data=PageSeparatorData(page_index=2)
-                ),
-                *make_text_spans(
-                    self.soup,
-                    "| Row 2    | Data 2   |",
-                ),
-            ],
-        )
-
-        # Act
-        table_tag = render_table(self.context, tag)
-
-        # Assert
-        assert normalized_html_str(str(table_tag)) == normalized_html_str(
-            """
-            <table>
-                <thead>
-                    <tr>
-                        <th>Column 1</th>
-                        <th>Column 2<a data-spec="page_separator" data-page_index="1"></a></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>Row 1</td>
-                        <td>Data 1<a data-spec="page_separator" data-page_index="2"></a></td>
-                    </tr>
-                    <tr>
-                        <td>Row 2</td>
-                        <td>Data 2</td>
-                    </tr>
-                </tbody>
-            </table>
-            """
-        )
-
-
-class TestRenderTableDescription(BaseTestCase):
-
-    def test_render_table_description_with_page_separators(self):
-        # Arrange
-        tag = make_semantic_tag(
-            self.soup,
-            TableDescriptionSegmentationSpec,
-            contents=[
-                *make_text_spans(self.soup, "This is a description of the table."),
-                make_semantic_tag(
-                    self.soup, PageSeparatorSpec, data=PageSeparatorData(page_index=1)
-                ),
-                *make_text_spans(self.soup, "This is another part of the description."),
-            ],
-        )
-
-        # Act
-        table_description_elements = list(render_table_description(self.context, tag))
-
-        # Assert
-        assert_html_list_equal(
-            table_description_elements,
-            [
-                "<br/>",
-                "This is a description of the table.",
-                '<a data-page_index="1" data-spec="page_separator"></a>',
-                "<br/>",
-                "This is another part of the description.",
-            ],
-        )
-
-
-class TestRenderList(BaseTestCase):
-
-    def test_render_list_with_page_separator(self):
-        # Arrange
-        tag = make_semantic_tag(
-            self.soup,
-            ListSegmentationSpec,
-            contents=[
-                *make_text_spans(self.soup, "- Item 1"),
-                make_semantic_tag(
-                    self.soup, PageSeparatorSpec, data=PageSeparatorData(page_index=1)
-                ),
-                *make_text_spans(self.soup, "- Item 2"),
-            ],
-        )
-
-        # Act
-        list_tag = render_list(self.context, tag)
-
-        # Assert
-        assert normalized_html_str(str(list_tag)) == normalized_html_str(
-            """
-            <ul>
-                <li>- Item 1<a data-spec="page_separator" data-page_index="1"></a></li>
-                <li>- Item 2</li>
-            </ul>
-            """
-        )
-
-    def test_render_nested_list(self):
-        # Arrange
-        tag = make_semantic_tag(
-            self.soup,
-            ListSegmentationSpec,
-            contents=[
-                *make_text_spans(
-                    self.soup, "- Item 1", "  - Subitem 1.1", "  - Subitem 1.2", "- Item 2"
-                ),
-            ],
-        )
-
-        # Act
-        list_tag = render_list(self.context, tag)
-
-        # Assert
-        assert normalized_html_str(str(list_tag)) == normalized_html_str(
-            """
-            <ul>
-                <li>- Item 1
-                    <ul>
-                        <li>- Subitem 1.1</li>
-                        <li>- Subitem 1.2</li>
-                    </ul>
-                </li>
-                <li>- Item 2</li>
-            </ul>
-            """
-        )
-
-    def test_render_list_text_span(self):
-        # Arrange
-        tag = make_semantic_tag(
-            self.soup,
-            ListSegmentationSpec,
-            contents=[
-                make_semantic_tag(
-                    self.soup,
-                    TextSpanSegmentationSpec,
-                    contents=["- Item 1", " This is a continuation of the previous sentence."],
-                    data=TextSpanSegmentationData(start=[0, 0, 0], end=[0, 1, 48]),
-                ),
-                *make_text_spans(self.soup, "- Item 2"),
-            ],
-        )
-
-        # Act
-        list_tag = render_list(self.context, tag)
-
-        # Assert
-        assert normalized_html_str(str(list_tag)) == normalized_html_str(
-            """
-            <ul>
-                <li>- Item 1 This is a continuation of the previous sentence.</li>
-                <li>- Item 2</li>
-            </ul>
-            """
-        )
-
-
 class TestParseImage(BaseTestCase):
 
     def test_parse_image(self):
@@ -739,28 +505,4 @@ class TestParseAddresses(BaseTestCase):
                 ", 75002 Paris. Some text after",
             ],
             ignore_text_span_data=True,
-        )
-
-
-class TestRenderBlockQuote(BaseTestCase):
-
-    def test_render_blockquote(self):
-        # Arrange
-        tag = make_semantic_tag(
-            self.soup,
-            BlockquoteSegmentationSpec,
-            contents=make_text_spans(self.soup, "This is", "a blockquote"),
-        )
-
-        # Act
-        blockquote_tag = render_blockquote(self.context, tag)
-
-        # Assert
-        assert normalized_html_str(str(blockquote_tag)) == normalized_html_str(
-            """
-            <blockquote>
-                <p>This is</p>
-                <p>a blockquote</p>
-            </blockquote>
-            """
         )

--- a/arretify/step_segmentation/content.py
+++ b/arretify/step_segmentation/content.py
@@ -16,18 +16,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Dict, Optional, Iterator, Sequence, cast
+from typing import Dict, Optional, Iterator, Sequence
 import logging
 
-from bs4 import Tag
 
 from arretify.types import DocumentContext, ProtectedTag, SectionType, ProtectedTagOrStr
 from arretify.utils.html_create import make_semantic_tag
 from arretify.utils.html_semantic import (
-    SemanticTagData,
-    SemanticTagSpec,
     get_semantic_tag_data,
-    get_semantic_tag_spec,
     is_semantic_tag,
     set_semantic_tag_data,
 )
@@ -44,19 +40,12 @@ from arretify.step_segmentation.semantic_tag_specs import (
 )
 from arretify.semantic_tag_specs import (
     AlineaData,
-    AlineaSpec,
     PageFooterSpec,
     PageSeparatorSpec,
-    SectionData,
-    SectionSpec,
-    SectionTitleSpecs,
     TableOfContentsSpec,
 )
 from arretify.errors import ErrorCodes
 from .basic_elements import (
-    render_basic_elements,
-    render_inline_quotes,
-    render_text_span,
     parse_tables,
     parse_lists,
     parse_images,
@@ -114,26 +103,6 @@ def parse_content(
     elements = parse_section_titles(context, elements)
     elements = parse_sections(context, elements)
     return elements
-
-
-def render_content(
-    context: DocumentContext,
-    spec: SemanticTagSpec,
-    elements: Sequence[ProtectedTagOrStr],
-) -> ProtectedTag:
-    contents: list[ProtectedTagOrStr] = []
-    for tag in elements:
-        if is_semantic_tag(tag, spec_in=[SectionSegmentationSpec]):
-            contents.append(render_section(context, tag))
-        elif is_semantic_tag(tag, spec_in=[TableOfContentsSpec]):
-            contents.append(tag)
-        else:
-            raise ValueError(f"Unexpected element {tag}")
-    return make_semantic_tag(
-        context.protected_soup,
-        spec,
-        contents=contents,
-    )
 
 
 def parse_section_titles(
@@ -402,69 +371,6 @@ def parse_sections(
             pile = []
 
 
-def render_section_title(
-    context: DocumentContext,
-    tag: ProtectedTag,
-) -> ProtectedTag:
-    if not is_semantic_tag(tag, spec_in=[SectionTitleSegmentationSpec]):
-        raise ValueError("Tag must be a section title")
-
-    segmentation_section_data = get_semantic_tag_data(SectionTitleSegmentationSpec, tag)
-    SectionTitleSpec = SectionTitleSpecs[cast(int, segmentation_section_data.level)]
-    section_title_data = SemanticTagData(error_codes=segmentation_section_data.error_codes)
-
-    return make_semantic_tag(
-        context.protected_soup,
-        SectionTitleSpec,
-        contents=[get_string(tag)],
-        data=section_title_data,
-    )
-
-
-def render_section(
-    context: DocumentContext,
-    tag: ProtectedTag,
-) -> ProtectedTag:
-    if not is_semantic_tag(tag, spec_in=[SectionSegmentationSpec]):
-        raise ValueError("Tag must be a section")
-
-    assert is_semantic_tag(
-        tag.contents[0], spec_in=[SectionTitleSegmentationSpec]
-    ), "First tag must be a section title"
-    section_title: ProtectedTag = tag.contents[0]
-
-    contents: list[ProtectedTagOrStr] = []
-    for element in tag.contents:
-        if is_semantic_tag(element, spec_in=[SectionTitleSegmentationSpec]):
-            contents.append(render_section_title(context, element))
-        elif is_semantic_tag(element, spec_in=[SectionSegmentationSpec]):
-            contents.append(render_section(context, element))
-        elif is_semantic_tag(element, spec_in=[AlineaSegmentationSpec]):
-            contents.append(render_alinea(context, element))
-        elif is_semantic_tag(
-            element, spec_in=[PageFooterSpec, PageSeparatorSpec, TableOfContentsSpec]
-        ):
-            contents.append(element)
-        elif isinstance(element, str):
-            contents.append(element)
-        elif is_semantic_tag(element):
-            raise ValueError(
-                f"Unexpected tag {get_semantic_tag_spec(element).spec_name} in section contents"
-            )
-
-    section_data = get_semantic_tag_data(SectionTitleSegmentationSpec, section_title)
-    return make_semantic_tag(
-        context.protected_soup,
-        SectionSpec,
-        data=SectionData(
-            type=section_data.type,
-            number=section_data.number,
-            title=section_data.title,
-        ),
-        contents=contents,
-    )
-
-
 # ALINEA : "Constitue un alinéa toute phrase, tout mot, tout ensemble de phrases ou de
 # mots commençant à la ligne, précédés ou non d’un tiret, d’un point, d’une
 # numérotation ou de guillemets, sans qu’il y ait lieu d’établir des distinctions selon
@@ -526,31 +432,3 @@ def parse_alineas(
             ),
         )
         alinea_count += 1
-
-
-def render_alinea(
-    context: DocumentContext,
-    tag: ProtectedTag,
-) -> ProtectedTag:
-    contents: list[ProtectedTagOrStr] = []
-    for element in tag.contents:
-        if is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec]):
-            # TODO : move render_inline_quotes inside render_text_span
-            text_span_elements = render_text_span(context, element)
-            for text_span_element in text_span_elements:
-                if isinstance(text_span_element, str):
-                    contents.extend(render_inline_quotes(context, text_span_element))
-                else:
-                    contents.append(text_span_element)
-        elif isinstance(element, Tag):
-            contents.extend(render_basic_elements(context, element))
-        elif isinstance(element, str):
-            contents.extend(render_inline_quotes(context, element))
-        else:
-            raise ValueError(f"Unexpected tag {element} in alinea contents")
-    return make_semantic_tag(
-        context.protected_soup,
-        AlineaSpec,
-        data=get_semantic_tag_data(AlineaSegmentationSpec, tag),
-        contents=contents,
-    )

--- a/arretify/step_segmentation/content_test.py
+++ b/arretify/step_segmentation/content_test.py
@@ -25,14 +25,11 @@ from arretify.semantic_tag_specs import (
     AlineaData,
 )
 from arretify.utils.html_create import make_semantic_tag
-from arretify.utils.testing import create_document_context, normalized_html_str
+from arretify.utils.testing import create_document_context
 from .content import (
     parse_section_titles,
     parse_sections,
     parse_alineas,
-    render_alinea,
-    render_section_title,
-    render_section,
 )
 from .testing import (
     assert_elements_equal,
@@ -609,103 +606,4 @@ class TestParseAlineas(BaseTestCase):
             ],
             ignore_text_span_data=True,
             ignore_data_if_omitted=True,
-        )
-
-
-class TestRenderAlinea(BaseTestCase):
-
-    def test_simple(self):
-        # Arrange
-        alinea = make_semantic_tag(
-            self.soup,
-            AlineaSegmentationSpec,
-            contents=make_text_spans(self.soup, "This is an alinea."),
-            data=AlineaData(number="1"),
-        )
-
-        # Act
-        result = render_alinea(self.context, alinea)
-
-        # Assert
-        assert normalized_html_str(str(result)) == normalized_html_str(
-            """
-            <div data-spec="alinea" data-number="1">
-                This is an alinea.
-            </div>
-            """
-        )
-
-
-class TestRenderSection(BaseTestCase):
-
-    def test_simple(self):
-        # Arrange
-        tag = make_semantic_tag(
-            self.soup,
-            SectionSegmentationSpec,
-            contents=[
-                make_semantic_tag(
-                    self.soup,
-                    SectionTitleSegmentationSpec,
-                    contents=make_text_spans(self.soup, "Article 1 : Disposition"),
-                    data=SectionTitleSegmentationData(
-                        level=0,
-                        number="1",
-                        title="Disposition",
-                        type="article",
-                    ),
-                ),
-                make_semantic_tag(
-                    self.soup,
-                    AlineaSegmentationSpec,
-                    contents=make_text_spans(self.soup, "Bla bla bla ..."),
-                    data=AlineaData(number="1"),
-                ),
-            ],
-        )
-
-        # Act
-        result = render_section(self.context, tag)
-
-        # Assert
-        assert normalized_html_str(str(result)) == normalized_html_str(
-            """
-            <section data-spec="section" data-number="1" data-title="Disposition" data-type="article">
-                <h2 data-spec="section_title">
-                    Article 1 : Disposition
-                </h2>
-                <div data-spec="alinea" data-number="1">
-                    Bla bla bla ...
-                </div>
-            </section>
-            """  # noqa: E501
-        )
-
-
-class TestRenderSectionTitle(BaseTestCase):
-
-    def test_simple(self):
-        # Arrange
-        section_title = make_semantic_tag(
-            self.soup,
-            SectionTitleSegmentationSpec,
-            contents=make_text_spans(self.soup, "Titre I - Introduction"),
-            data=SectionTitleSegmentationData(
-                level=0,
-                number="I",
-                title="Introduction",
-                type="titre",
-            ),
-        )
-
-        # Act
-        result = render_section_title(self.context, section_title)
-
-        # Assert
-        assert normalized_html_str(str(result)) == normalized_html_str(
-            """
-            <h2 data-spec="section_title">
-                Titre I - Introduction
-            </h2>
-            """
         )

--- a/arretify/step_segmentation/document_elements.py
+++ b/arretify/step_segmentation/document_elements.py
@@ -124,6 +124,25 @@ def _table_of_contents_while_condition(elements: Sequence[ProtectedTagOrStr], in
     return False
 
 
+def _render_table_of_contents(
+    context: DocumentContext,
+    contents: Sequence[ProtectedTagOrStr],
+) -> ProtectedTag:
+    rendered_contents: list[ProtectedTagOrStr] = []
+    for element in contents:
+        if is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec]):
+            rendered_contents.append(get_string(element))
+        elif is_semantic_tag(element, spec_in=[PageSeparatorSpec]):
+            rendered_contents.append(element)
+        else:
+            raise ValueError(f"Unexpected element in table of contents: {element}")
+    return make_semantic_tag(
+        context.protected_soup,
+        TableOfContentsSpec,
+        contents=wrap_in_tag(context.protected_soup, "div", rendered_contents),
+    )
+
+
 def parse_page_footers(
     context: DocumentContext,
     elements: Sequence[ProtectedTagOrStr],
@@ -168,22 +187,3 @@ def initialize_document_structure(
                     end=[page_index, line_index, len(line) - 1],
                 ),
             )
-
-
-def _render_table_of_contents(
-    context: DocumentContext,
-    contents: Sequence[ProtectedTagOrStr],
-) -> ProtectedTag:
-    rendered_contents: list[ProtectedTagOrStr] = []
-    for element in contents:
-        if is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec]):
-            rendered_contents.append(get_string(element))
-        elif is_semantic_tag(element, spec_in=[PageSeparatorSpec]):
-            rendered_contents.append(element)
-        else:
-            raise ValueError(f"Unexpected element in table of contents: {element}")
-    return make_semantic_tag(
-        context.protected_soup,
-        TableOfContentsSpec,
-        contents=wrap_in_tag(context.protected_soup, "div", rendered_contents),
-    )

--- a/arretify/step_segmentation/header.py
+++ b/arretify/step_segmentation/header.py
@@ -24,7 +24,6 @@ from arretify.utils.html import is_tag
 from arretify.utils.html_semantic import (
     SemanticTagSpec,
     is_semantic_tag,
-    get_semantic_tag_spec,
 )
 from arretify.utils.html_create import (
     make_semantic_tag,
@@ -44,10 +43,6 @@ from arretify.semantic_tag_specs import (
     VisaSpec,
     MotifSpec,
     SupplementaryMotifInfoSpec,
-    PageSeparatorSpec,
-    PageFooterSpec,
-    TableOfContentsSpec,
-    HeaderSpec,
 )
 from arretify.step_segmentation.semantic_tag_specs import (
     ListSegmentationSpec,
@@ -75,7 +70,7 @@ from .core import (
     get_strings,
     TRANSPARENT_TAG_SPECS,
 )
-from .basic_elements import parse_lists, render_list, render_text_span
+from .basic_elements import parse_lists
 
 
 def parse_header(
@@ -103,54 +98,6 @@ def parse_header(
     )
     elements = parse_visa_and_motif_elements(context, elements)
     return elements
-
-
-def render_header(
-    context: DocumentContext,
-    elements: Sequence[ProtectedTagOrStr],
-) -> ProtectedTag:
-    contents: list[ProtectedTagOrStr] = []
-    for element in elements:
-        if is_semantic_tag(element, spec_in=[VisaSegmentationSpec, MotifSegmentationSpec]):
-            contents.append(render_visa_motif(context, element))
-        # All header elements other than the ones above
-        # are treated in a generic way.
-        elif is_semantic_tag(
-            element,
-            spec_in=HEADER_ELEMENTS_SPECS,
-        ):
-            contents.append(element)
-        elif is_semantic_tag(
-            element, spec_in=[PageSeparatorSpec, PageFooterSpec, TableOfContentsSpec]
-        ):
-            contents.append(element)
-        elif is_semantic_tag(element, spec_in=[ListSegmentationSpec]):
-            contents.append(render_list(context, element))
-        elif is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec]):
-            contents.append(
-                make_new_tag(
-                    context.protected_soup,
-                    "div",
-                    contents=render_text_span(context, element),
-                )
-            )
-
-        elif is_tag(element, tag_name_in=["img"]):
-            contents.append(element)
-
-        elif is_semantic_tag(element):
-            raise ValueError(
-                f"Unexpected tag {get_semantic_tag_spec(element).spec_name} in content"
-            )
-
-        elif isinstance(element, str):
-            contents.extend(wrap_in_tag(context.protected_soup, "div", [element]))
-
-    return make_semantic_tag(
-        context.protected_soup,
-        HeaderSpec,
-        contents=contents,
-    )
 
 
 # -------------------- Header elements -------------------- #
@@ -647,28 +594,3 @@ def _parse_visa_and_motif_elements_pass3(
 
         else:
             yield element
-
-
-def render_visa_motif(
-    context: DocumentContext,
-    tag: ProtectedTag,
-) -> ProtectedTag:
-    assert is_semantic_tag(tag, spec_in=[VisaSegmentationSpec, MotifSegmentationSpec])
-    contents: list[ProtectedTagOrStr] = []
-    spec = get_semantic_tag_spec(tag)
-
-    for element in tag.contents:
-        if is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec]):
-            contents.append(get_string(element))
-        elif is_semantic_tag(element, spec_in=[ListSegmentationSpec]):
-            contents.append(render_list(context, element))
-        elif is_semantic_tag(element, spec_in=[PageSeparatorSpec]):
-            contents.append(element)
-        else:
-            raise ValueError(f"Unexpected element {element} in visa/motif")
-
-    return make_semantic_tag(
-        context.protected_soup,
-        VISA_MOTIFS_RENDER_SPECS[spec],
-        contents=contents,
-    )

--- a/arretify/step_segmentation/header_test.py
+++ b/arretify/step_segmentation/header_test.py
@@ -19,7 +19,7 @@
 import unittest
 
 from arretify.utils.html_create import make_new_tag, make_semantic_tag, wrap_in_tag
-from arretify.utils.testing import create_document_context, normalized_html_str
+from arretify.utils.testing import create_document_context
 from arretify.semantic_tag_specs import (
     DateSpec,
     HonorarySpec,
@@ -40,7 +40,6 @@ from arretify.step_segmentation.semantic_tag_specs import (
 from .header import (
     _render_header_element,
     parse_visa_and_motif_elements,
-    render_visa_motif,
     parse_arrete_title_element,
     parse_emblem_element,
     parse_entity_element,
@@ -699,32 +698,4 @@ class TestParseSupplementaryMotifInfo(BaseTestCase):
                 ),
             ],
             ignore_text_span_data=True,
-        )
-
-
-class TestRenderVisaMotif(BaseTestCase):
-
-    def test_render_simple(self):
-        # Arrange
-        tag = make_semantic_tag(
-            self.soup,
-            VisaSegmentationSpec,
-            contents=make_text_spans(
-                self.soup,
-                "Vu le code de l'environnement, et notamment ses titres "
-                "1er et 4 des parties réglementaires et législatives du livre V ;",
-            ),
-        )
-
-        # Act
-        rendered = render_visa_motif(self.context, tag)
-
-        # Assert
-        assert normalized_html_str(str(rendered)) == normalized_html_str(
-            """
-            <div data-spec="visa">
-                Vu le code de l'environnement, et notamment ses titres
-                1er et 4 des parties réglementaires et législatives du livre V ;
-            </div>
-            """
         )

--- a/arretify/step_segmentation/parse_arrete.py
+++ b/arretify/step_segmentation/parse_arrete.py
@@ -19,18 +19,14 @@
 from typing import Iterator, Callable, Sequence
 
 from arretify.types import DocumentContext, SectionType, ProtectedTagOrStr
-from arretify.semantic_tag_specs import (
-    AppendixSpec,
-    MainSpec,
-)
 from arretify.utils.html_create import make_semantic_tag, replace_children, is_semantic_tag
 from arretify.utils.functional import chain_functions, iter_func_to_list
 from arretify.utils.split_merge import (
     split_before_match,
 )
-from .header import parse_header, render_header
+from .header import parse_header
 from .titles_detection import parse_title_info
-from .content import parse_content, render_content, is_title
+from .content import parse_content, is_title
 from .core import (
     pick_text_spans,
     get_string,
@@ -107,19 +103,6 @@ def parse_arrete(context: DocumentContext, pages: Sequence[str]) -> Iterator[Pro
             AppendixSegmentationSpec,
             contents=parse_content(context, elements),
         )
-
-
-@iter_func_to_list
-def render_arrete(
-    context: DocumentContext, elements: Sequence[ProtectedTagOrStr]
-) -> Iterator[ProtectedTagOrStr]:
-    for element in elements:
-        if is_semantic_tag(element, spec_in=[HeaderSegmentationSpec]):
-            yield render_header(context, element.contents)
-        elif is_semantic_tag(element, spec_in=[MainSegmentationSpec]):
-            yield render_content(context, MainSpec, element.contents)
-        elif is_semantic_tag(element, spec_in=[AppendixSegmentationSpec]):
-            yield render_content(context, AppendixSpec, element.contents)
 
 
 def _make_text_span_parser(

--- a/arretify/step_segmentation/render_contents.py
+++ b/arretify/step_segmentation/render_contents.py
@@ -1,0 +1,439 @@
+#
+# Copyright (c) 2025 Direction générale de la prévention des risques (DGPR).
+#
+# This file is part of Arrêtify.
+# See https://github.com/mte-dgpr/arretify for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from typing import Iterator, List, Sequence, Tuple
+from arretify.regex_utils.core import PatternProxy
+from arretify.regex_utils.functional import map_matches
+from arretify.regex_utils.split import split_string_with_regex
+from arretify.semantic_tag_specs import (
+    AlineaSpec,
+    AppendixSpec,
+    HeaderSpec,
+    MainSpec,
+    PageSeparatorSpec,
+    SectionData,
+    SectionSpec,
+    SectionTitleSpecs,
+)
+from arretify.step_segmentation.core import get_string
+from arretify.step_segmentation.header import VISA_MOTIFS_RENDER_SPECS
+from arretify.step_segmentation.semantic_tag_specs import (
+    AlineaSegmentationSpec,
+    AppendixSegmentationSpec,
+    BlockquoteSegmentationSpec,
+    HeaderSegmentationSpec,
+    ListSegmentationSpec,
+    MainSegmentationSpec,
+    MotifSegmentationSpec,
+    SectionSegmentationSpec,
+    SectionTitleSegmentationSpec,
+    TableDescriptionSegmentationSpec,
+    TableSegmentationSpec,
+    TextSpanSegmentationSpec,
+    VisaSegmentationSpec,
+)
+from arretify.types import DocumentContext, ProtectedTag, ProtectedTagOrStr
+from arretify.utils.functional import iter_func_to_list
+from arretify.utils.html_create import make_new_tag, make_semantic_tag, replace_children
+from arretify.utils.html_semantic import (
+    SemanticTagData,
+    get_semantic_tag_data,
+    get_semantic_tag_spec,
+    is_semantic_tag,
+)
+from arretify.utils.markdown_parsing import (
+    LIST_PATTERN,
+    TABLE_HEADER_SEPARATOR_PATTERN,
+    parse_markdown_table,
+)
+
+
+@iter_func_to_list
+def render_contents(
+    context: DocumentContext,
+    contents: Sequence[ProtectedTagOrStr],
+) -> Iterator[ProtectedTagOrStr]:
+    """
+    Recursively renders the segmentation tags into their final HTML representation.
+    """
+    for element in contents:
+        if is_semantic_tag(element, spec_in=[HeaderSegmentationSpec]):
+            yield render_header(context, element)
+
+        elif is_semantic_tag(element, spec_in=[MainSegmentationSpec]):
+            yield render_main(
+                context,
+                element,
+            )
+
+        elif is_semantic_tag(element, spec_in=[AppendixSegmentationSpec]):
+            yield render_appendix(
+                context,
+                element,
+            )
+
+        elif is_semantic_tag(element, spec_in=[SectionSegmentationSpec]):
+            yield render_section(context, element)
+
+        elif is_semantic_tag(element, spec_in=[SectionTitleSegmentationSpec]):
+            yield render_section_title(context, element)
+
+        elif is_semantic_tag(element, spec_in=[AlineaSegmentationSpec]):
+            yield render_alinea(context, element)
+
+        elif is_semantic_tag(element, spec_in=[VisaSegmentationSpec, MotifSegmentationSpec]):
+            yield render_visa_motif(context, element)
+
+        elif is_semantic_tag(element, spec_in=[ListSegmentationSpec]):
+            yield render_list(context, element)
+
+        elif is_semantic_tag(element, spec_in=[BlockquoteSegmentationSpec]):
+            yield render_blockquote(context, element)
+
+        elif is_semantic_tag(element, spec_in=[TableSegmentationSpec]):
+            yield render_table(context, element)
+
+        elif is_semantic_tag(element, spec_in=[TableDescriptionSegmentationSpec]):
+            yield from render_table_description(context, element)
+
+        else:
+            yield element
+
+
+# -------------------- Arrete segmentation -------------------- #
+
+
+def render_section_title(
+    context: DocumentContext,
+    tag: ProtectedTag,
+) -> ProtectedTag:
+    if not is_semantic_tag(tag, spec_in=[SectionTitleSegmentationSpec]):
+        raise ValueError("Tag must be a section title")
+
+    segmentation_section_data = get_semantic_tag_data(SectionTitleSegmentationSpec, tag)
+    assert segmentation_section_data.level is not None, "Section level must be defined"
+    SectionTitleSpec = SectionTitleSpecs[segmentation_section_data.level]
+    section_title_data = SemanticTagData(error_codes=segmentation_section_data.error_codes)
+
+    return make_semantic_tag(
+        context.protected_soup,
+        SectionTitleSpec,
+        contents=[get_string(tag)],
+        data=section_title_data,
+    )
+
+
+def render_section(
+    context: DocumentContext,
+    tag: ProtectedTag,
+) -> ProtectedTag:
+    assert is_semantic_tag(
+        tag.contents[0], spec_in=[SectionTitleSegmentationSpec]
+    ), "First tag must be a section title"
+    section_title: ProtectedTag = tag.contents[0]
+    section_data = get_semantic_tag_data(SectionTitleSegmentationSpec, section_title)
+    return make_semantic_tag(
+        context.protected_soup,
+        SectionSpec,
+        data=SectionData(
+            type=section_data.type,
+            number=section_data.number,
+            title=section_data.title,
+        ),
+        contents=render_contents(context, tag.contents),
+    )
+
+
+def render_alinea(
+    context: DocumentContext,
+    tag: ProtectedTag,
+) -> ProtectedTag:
+    contents: list[ProtectedTagOrStr] = []
+    for element in render_contents(context, tag.contents):
+        if is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec]):
+            # TODO : move render_inline_quotes inside render_text_span
+            text_span_elements = render_text_span(context, element)
+            for text_span_element in text_span_elements:
+                if isinstance(text_span_element, str):
+                    contents.extend(render_inline_quotes(context, text_span_element))
+                else:
+                    contents.append(text_span_element)
+        else:
+            contents.append(element)
+
+    return make_semantic_tag(
+        context.protected_soup,
+        AlineaSpec,
+        data=get_semantic_tag_data(AlineaSegmentationSpec, tag),
+        contents=contents,
+    )
+
+
+# -------------------- Header / Main -------------------- #
+
+
+def render_header(
+    context: DocumentContext,
+    tag: ProtectedTag,
+) -> ProtectedTag:
+    contents: list[ProtectedTagOrStr] = []
+    for element in render_contents(context, tag.contents):
+        if is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec]):
+            contents.append(
+                make_new_tag(
+                    context.protected_soup,
+                    "div",
+                    contents=render_text_span(context, element),
+                )
+            )
+        else:
+            contents.append(element)
+
+    return make_semantic_tag(
+        context.protected_soup,
+        HeaderSpec,
+        contents=contents,
+    )
+
+
+def render_visa_motif(
+    context: DocumentContext,
+    tag: ProtectedTag,
+) -> ProtectedTag:
+    assert is_semantic_tag(tag, spec_in=[VisaSegmentationSpec, MotifSegmentationSpec])
+    contents: list[ProtectedTagOrStr] = []
+    spec = get_semantic_tag_spec(tag)
+
+    for element in render_contents(context, tag.contents):
+        if is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec]):
+            contents.append(get_string(element))
+        else:
+            contents.append(element)
+
+    return make_semantic_tag(
+        context.protected_soup,
+        VISA_MOTIFS_RENDER_SPECS[spec],
+        contents=contents,
+    )
+
+
+def render_main(
+    context: DocumentContext,
+    tag: ProtectedTagOrStr,
+) -> ProtectedTag:
+    return make_semantic_tag(
+        context.protected_soup,
+        MainSpec,
+        contents=render_contents(context, tag.contents),
+    )
+
+
+def render_appendix(
+    context: DocumentContext,
+    tag: ProtectedTagOrStr,
+) -> ProtectedTag:
+    return make_semantic_tag(
+        context.protected_soup,
+        AppendixSpec,
+        contents=render_contents(context, tag.contents),
+    )
+
+
+# -------------------- List -------------------- #
+
+
+LEADING_WHITESPACES_PATTERN = PatternProxy(r"^\s+")
+"""Detect leading whitespaces."""
+
+
+def _list_indentation(line: str) -> int:
+    list_match = LIST_PATTERN.match(line)
+    if not list_match:
+        raise ValueError("Expected line to be a list element")
+    indentation = list_match.group("indentation")
+    assert indentation is not None
+    return len(indentation)
+
+
+def _clean_leading_whitespaces(line: str) -> str:
+    return LEADING_WHITESPACES_PATTERN.sub("", line)
+
+
+def render_list(
+    context: DocumentContext,
+    tag: ProtectedTag,
+) -> ProtectedTag:
+    elements, ul = _render_list(context, tag.contents)
+    assert len(elements) == 0, "Expected all lines to be consumed in list rendering"
+    return ul
+
+
+def _render_list(
+    context: DocumentContext,
+    elements_: Sequence[ProtectedTagOrStr],
+) -> Tuple[list[ProtectedTagOrStr], ProtectedTag]:
+    elements = list(elements_)
+    list_pile: list[ProtectedTag] = []
+    element = elements[0]
+    ref_indentation = _list_indentation(get_string(element))
+
+    while elements:
+        element = elements[0]
+
+        if is_semantic_tag(element, spec_in=[PageSeparatorSpec]):
+            list_pile[-1] = replace_children(list_pile[-1], list_pile[-1].contents + [element])
+            elements.pop(0)
+
+        elif is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec]):
+            current_indentation = _list_indentation(get_string(element))
+
+            if current_indentation == ref_indentation:
+                li_contents = list(render_text_span(context, element))
+                if isinstance(li_contents[0], str):
+                    li_contents[0] = _clean_leading_whitespaces(li_contents[0])
+                list_pile.append(make_new_tag(context.protected_soup, "li", contents=li_contents))
+                elements.pop(0)
+
+            elif current_indentation > ref_indentation:
+                elements, nested_ul = _render_list(context, elements)
+                list_pile[-1] = replace_children(
+                    list_pile[-1], list_pile[-1].contents + [nested_ul]
+                )
+
+            # If the indentation is less than the reference indentation,
+            # we exit the function and go up one level.
+            else:
+                break
+
+        else:
+            raise ValueError(f"Unexpected element {element} in list rendering.")
+
+    return elements, make_new_tag(context.protected_soup, "ul", contents=list_pile)
+
+
+# -------------------- Table -------------------- #
+
+
+def render_table(
+    _: DocumentContext,
+    tag: ProtectedTag,
+) -> ProtectedTag:
+    pile: list[str] = []
+    has_table_header = False
+    transparent_tags: list[Tuple[int, ProtectedTag]] = []
+    for element in tag.contents:
+        if is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec]):
+            element_str = get_string(element)
+            pile.append(element_str)
+            if bool(TABLE_HEADER_SEPARATOR_PATTERN.match(element_str)):
+                has_table_header = True
+        elif is_semantic_tag(element, spec_in=[PageSeparatorSpec]):
+            table_tag = parse_markdown_table(pile)
+            # Get the right table row for inserting the transparent tag.
+            # If the table has a header, the `pile` contains a header
+            # separation line (e.g. "|---|---|---|"), which is not
+            # counting as a row in the final html table tag.
+            row_index = len(pile) - 1 - int(has_table_header)
+            transparent_tags.append((row_index, element))
+        else:
+            raise ValueError(f"Unexpected element type {type(element)} in table rendering.")
+
+    table_tag = parse_markdown_table(pile)
+
+    # Insert transparent tags in their corresponding table rows.
+    table_rows = table_tag.select("tr")
+    for row_index, transparent_tag in transparent_tags:
+        if row_index < len(table_rows) and row_index >= 0:
+            last_cell_tag = table_rows[row_index].select("td, th")[-1]
+            replace_children(last_cell_tag, last_cell_tag.contents + [transparent_tag])
+        else:
+            raise ValueError(f"Invalid index {row_index} in table rendering. ")
+
+    return table_tag
+
+
+def render_table_description(
+    context: DocumentContext,
+    tag: ProtectedTag,
+) -> Iterator[ProtectedTagOrStr]:
+    for element in tag.contents:
+        if is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec]):
+            yield make_new_tag(context.protected_soup, "br")
+            yield get_string(element)
+        elif is_semantic_tag(element, spec_in=[PageSeparatorSpec]):
+            yield element
+        else:
+            raise ValueError(
+                f"Unexpected element type {type(element)} in table description rendering."
+            )
+
+
+# -------------------- Blockquote -------------------- #
+
+
+def render_blockquote(
+    context: DocumentContext,
+    tag: ProtectedTag,
+) -> ProtectedTag:
+    contents: List[ProtectedTagOrStr] = []
+    for element in render_contents(context, tag.contents):
+        if is_semantic_tag(element, spec_in=[TextSpanSegmentationSpec]):
+            contents.append(
+                make_new_tag(
+                    context.protected_soup,
+                    "p",
+                    # TODO : should be parsed like other tags, instead of being
+                    # rendered here on the fly. This would also make parsing blockquote easier.
+                    contents=render_inline_quotes(context, get_string(element)),
+                )
+            )
+        else:
+            contents.append(element)
+
+    return make_new_tag(context.protected_soup, "blockquote", contents=contents)
+
+
+# -------------------- Misc -------------------- #
+INLINE_QUOTE_PATTERN = PatternProxy(r'"(?P<quoted>[^"]+)"')
+"""Detect if a sentence has inline quotes."""
+
+
+def render_inline_quotes(context: DocumentContext, string: str) -> Iterator[ProtectedTagOrStr]:
+    return map_matches(
+        split_string_with_regex(INLINE_QUOTE_PATTERN, string),
+        lambda inline_quote_match: make_new_tag(
+            context.protected_soup,
+            "q",
+            contents=[str(inline_quote_match.group("quoted"))],
+        ),
+    )
+
+
+@iter_func_to_list
+def render_text_span(
+    _: DocumentContext,
+    tag: ProtectedTag,
+) -> Iterator[ProtectedTagOrStr]:
+    for i, element in enumerate(tag.contents):
+        if isinstance(element, str):
+            # If this is not the last element, we add a space as separator.
+            yield element + " " * int(i < len(tag.contents) - 1)
+        elif is_semantic_tag(element):
+            yield element
+        else:
+            raise ValueError(f"Unexpected element type {type(element)} in text span rendering.")

--- a/arretify/step_segmentation/render_contents_test.py
+++ b/arretify/step_segmentation/render_contents_test.py
@@ -1,0 +1,425 @@
+#
+# Copyright (c) 2025 Direction générale de la prévention des risques (DGPR).
+#
+# This file is part of Arrêtify.
+# See https://github.com/mte-dgpr/arretify for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from arretify.semantic_tag_specs import AlineaData, PageSeparatorData, PageSeparatorSpec
+from arretify.step_segmentation.core_test import BaseTestCase
+from arretify.step_segmentation.render_contents import (
+    _list_indentation,
+    render_alinea,
+    render_blockquote,
+    render_inline_quotes,
+    render_list,
+    render_section,
+    render_section_title,
+    render_table,
+    render_table_description,
+    render_visa_motif,
+)
+from arretify.step_segmentation.semantic_tag_specs import (
+    AlineaSegmentationSpec,
+    BlockquoteSegmentationSpec,
+    ListSegmentationSpec,
+    SectionSegmentationSpec,
+    SectionTitleSegmentationData,
+    SectionTitleSegmentationSpec,
+    TableDescriptionSegmentationSpec,
+    TableSegmentationSpec,
+    TextSpanSegmentationData,
+    TextSpanSegmentationSpec,
+    VisaSegmentationSpec,
+)
+from arretify.step_segmentation.testing import make_text_spans
+from arretify.utils.html_create import make_semantic_tag
+from arretify.utils.testing import assert_html_list_equal, normalized_html_str
+
+
+class TestListIndentation(BaseTestCase):
+
+    def test_correct_indentation(self):
+        # Arrange
+        line = "    - Item in list"
+
+        # Act
+        result = _list_indentation(line)
+
+        # Assert
+        assert result == 4, "Should return the correct indentation level"
+
+    def test_no_indentation(self):
+        # Arrange
+        line = "- Item in list"
+
+        # Act
+        result = _list_indentation(line)
+
+        # Assert
+        assert result == 0, "Should return zero for no indentation"
+
+    def test_not_a_list_element(self):
+        # Arrange
+        line = "This is not a list item"
+
+        # Act / Assert
+        with self.assertRaises(ValueError) as context:
+            _list_indentation(line)
+        assert (
+            str(context.exception) == "Expected line to be a list element"
+        ), "Should raise ValueError for non-list lines"
+
+
+class TestRenderInlineQuotes(BaseTestCase):
+
+    def test_inline_quote(self):
+        # Arrange
+        line = 'bla bla "haha" bli bli'
+
+        # Act
+        result = render_inline_quotes(self.context, line)
+
+        # Assert
+        assert [str(element) for element in result] == [
+            "bla bla ",
+            "<q>haha</q>",
+            " bli bli",
+        ]
+
+
+class TestRenderTable(BaseTestCase):
+
+    def test_render_table_with_page_separators(self):
+        # Arrange
+        tag = make_semantic_tag(
+            self.soup,
+            TableSegmentationSpec,
+            contents=[
+                *make_text_spans(self.soup, "| Column 1 | Column 2 |", "|----------|----------|"),
+                make_semantic_tag(
+                    self.soup, PageSeparatorSpec, data=PageSeparatorData(page_index=1)
+                ),
+                *make_text_spans(
+                    self.soup,
+                    "| Row 1    | Data 1   |",
+                ),
+                make_semantic_tag(
+                    self.soup, PageSeparatorSpec, data=PageSeparatorData(page_index=2)
+                ),
+                *make_text_spans(
+                    self.soup,
+                    "| Row 2    | Data 2   |",
+                ),
+            ],
+        )
+
+        # Act
+        table_tag = render_table(self.context, tag)
+
+        # Assert
+        assert normalized_html_str(str(table_tag)) == normalized_html_str(
+            """
+            <table>
+                <thead>
+                    <tr>
+                        <th>Column 1</th>
+                        <th>Column 2<a data-spec="page_separator" data-page_index="1"></a></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Row 1</td>
+                        <td>Data 1<a data-spec="page_separator" data-page_index="2"></a></td>
+                    </tr>
+                    <tr>
+                        <td>Row 2</td>
+                        <td>Data 2</td>
+                    </tr>
+                </tbody>
+            </table>
+            """
+        )
+
+
+class TestRenderTableDescription(BaseTestCase):
+
+    def test_render_table_description_with_page_separators(self):
+        # Arrange
+        tag = make_semantic_tag(
+            self.soup,
+            TableDescriptionSegmentationSpec,
+            contents=[
+                *make_text_spans(self.soup, "This is a description of the table."),
+                make_semantic_tag(
+                    self.soup, PageSeparatorSpec, data=PageSeparatorData(page_index=1)
+                ),
+                *make_text_spans(self.soup, "This is another part of the description."),
+            ],
+        )
+
+        # Act
+        table_description_elements = list(render_table_description(self.context, tag))
+
+        # Assert
+        assert_html_list_equal(
+            table_description_elements,
+            [
+                "<br/>",
+                "This is a description of the table.",
+                '<a data-page_index="1" data-spec="page_separator"></a>',
+                "<br/>",
+                "This is another part of the description.",
+            ],
+        )
+
+
+class TestRenderList(BaseTestCase):
+
+    def test_render_list_with_page_separator(self):
+        # Arrange
+        tag = make_semantic_tag(
+            self.soup,
+            ListSegmentationSpec,
+            contents=[
+                *make_text_spans(self.soup, "- Item 1"),
+                make_semantic_tag(
+                    self.soup, PageSeparatorSpec, data=PageSeparatorData(page_index=1)
+                ),
+                *make_text_spans(self.soup, "- Item 2"),
+            ],
+        )
+
+        # Act
+        list_tag = render_list(self.context, tag)
+
+        # Assert
+        assert normalized_html_str(str(list_tag)) == normalized_html_str(
+            """
+            <ul>
+                <li>- Item 1<a data-spec="page_separator" data-page_index="1"></a></li>
+                <li>- Item 2</li>
+            </ul>
+            """
+        )
+
+    def test_render_nested_list(self):
+        # Arrange
+        tag = make_semantic_tag(
+            self.soup,
+            ListSegmentationSpec,
+            contents=[
+                *make_text_spans(
+                    self.soup, "- Item 1", "  - Subitem 1.1", "  - Subitem 1.2", "- Item 2"
+                ),
+            ],
+        )
+
+        # Act
+        list_tag = render_list(self.context, tag)
+
+        # Assert
+        assert normalized_html_str(str(list_tag)) == normalized_html_str(
+            """
+            <ul>
+                <li>- Item 1
+                    <ul>
+                        <li>- Subitem 1.1</li>
+                        <li>- Subitem 1.2</li>
+                    </ul>
+                </li>
+                <li>- Item 2</li>
+            </ul>
+            """
+        )
+
+    def test_render_list_text_span(self):
+        # Arrange
+        tag = make_semantic_tag(
+            self.soup,
+            ListSegmentationSpec,
+            contents=[
+                make_semantic_tag(
+                    self.soup,
+                    TextSpanSegmentationSpec,
+                    contents=["- Item 1", " This is a continuation of the previous sentence."],
+                    data=TextSpanSegmentationData(start=[0, 0, 0], end=[0, 1, 48]),
+                ),
+                *make_text_spans(self.soup, "- Item 2"),
+            ],
+        )
+
+        # Act
+        list_tag = render_list(self.context, tag)
+
+        # Assert
+        assert normalized_html_str(str(list_tag)) == normalized_html_str(
+            """
+            <ul>
+                <li>- Item 1 This is a continuation of the previous sentence.</li>
+                <li>- Item 2</li>
+            </ul>
+            """
+        )
+
+
+class TestRenderBlockQuote(BaseTestCase):
+
+    def test_render_blockquote(self):
+        # Arrange
+        tag = make_semantic_tag(
+            self.soup,
+            BlockquoteSegmentationSpec,
+            contents=make_text_spans(self.soup, "This is", "a blockquote"),
+        )
+
+        # Act
+        blockquote_tag = render_blockquote(self.context, tag)
+
+        # Assert
+        assert normalized_html_str(str(blockquote_tag)) == normalized_html_str(
+            """
+            <blockquote>
+                <p>This is</p>
+                <p>a blockquote</p>
+            </blockquote>
+            """
+        )
+
+
+class TestRenderAlinea(BaseTestCase):
+
+    def test_simple(self):
+        # Arrange
+        alinea = make_semantic_tag(
+            self.soup,
+            AlineaSegmentationSpec,
+            contents=make_text_spans(self.soup, "This is an alinea."),
+            data=AlineaData(number="1"),
+        )
+
+        # Act
+        result = render_alinea(self.context, alinea)
+
+        # Assert
+        assert normalized_html_str(str(result)) == normalized_html_str(
+            """
+            <div data-spec="alinea" data-number="1">
+                This is an alinea.
+            </div>
+            """
+        )
+
+
+class TestRenderSection(BaseTestCase):
+
+    def test_simple(self):
+        # Arrange
+        tag = make_semantic_tag(
+            self.soup,
+            SectionSegmentationSpec,
+            contents=[
+                make_semantic_tag(
+                    self.soup,
+                    SectionTitleSegmentationSpec,
+                    contents=make_text_spans(self.soup, "Article 1 : Disposition"),
+                    data=SectionTitleSegmentationData(
+                        level=0,
+                        number="1",
+                        title="Disposition",
+                        type="article",
+                    ),
+                ),
+                make_semantic_tag(
+                    self.soup,
+                    AlineaSegmentationSpec,
+                    contents=make_text_spans(self.soup, "Bla bla bla ..."),
+                    data=AlineaData(number="1"),
+                ),
+            ],
+        )
+
+        # Act
+        result = render_section(self.context, tag)
+
+        # Assert
+        assert normalized_html_str(str(result)) == normalized_html_str(
+            """
+            <section data-spec="section" data-number="1" data-title="Disposition" data-type="article">
+                <h2 data-spec="section_title">
+                    Article 1 : Disposition
+                </h2>
+                <div data-spec="alinea" data-number="1">
+                    Bla bla bla ...
+                </div>
+            </section>
+            """  # noqa: E501
+        )
+
+
+class TestRenderSectionTitle(BaseTestCase):
+
+    def test_simple(self):
+        # Arrange
+        section_title = make_semantic_tag(
+            self.soup,
+            SectionTitleSegmentationSpec,
+            contents=make_text_spans(self.soup, "Titre I - Introduction"),
+            data=SectionTitleSegmentationData(
+                level=0,
+                number="I",
+                title="Introduction",
+                type="titre",
+            ),
+        )
+
+        # Act
+        result = render_section_title(self.context, section_title)
+
+        # Assert
+        assert normalized_html_str(str(result)) == normalized_html_str(
+            """
+            <h2 data-spec="section_title">
+                Titre I - Introduction
+            </h2>
+            """
+        )
+
+
+class TestRenderVisaMotif(BaseTestCase):
+
+    def test_render_simple(self):
+        # Arrange
+        tag = make_semantic_tag(
+            self.soup,
+            VisaSegmentationSpec,
+            contents=make_text_spans(
+                self.soup,
+                "Vu le code de l'environnement, et notamment ses titres "
+                "1er et 4 des parties réglementaires et législatives du livre V ;",
+            ),
+        )
+
+        # Act
+        rendered = render_visa_motif(self.context, tag)
+
+        # Assert
+        assert normalized_html_str(str(rendered)) == normalized_html_str(
+            """
+            <div data-spec="visa">
+                Vu le code de l'environnement, et notamment ses titres
+                1er et 4 des parties réglementaires et législatives du livre V ;
+            </div>
+            """
+        )


### PR DESCRIPTION
Simplification du système de rendering dans le step de segmentation - la segmentation étant faite en 2 étapes : structure temporaire pour ségmenter, puis rendering de cette structure temporaire en structure finale. Fichiers à regarder en particulier : 

- arretify\step_segmentation\render_contents.py