### PR TITLE
added tableau section reference detection (#78)

### DIFF
--- a/arretify/law_data/apis/eurlex.py
+++ b/arretify/law_data/apis/eurlex.py
@@ -26,7 +26,12 @@ from arretify._vendor.clients_api_droit.clients_api_droit.eurlex import (
     EurlexSettings,
     search_act,
 )
-from arretify.errors import ErrorCodes, SettingsError, catch_and_convert_into_arretify_error
+from arretify.errors import (
+    ArretifyError,
+    ErrorCodes,
+    SettingsError,
+    catch_and_convert_into_arretify_error,
+)
 from arretify.types import SessionContext
 from arretify.utils.dev_cache import use_dev_cache
 
@@ -69,5 +74,7 @@ def get_eu_act_url_with_year_and_num(
 
 def _assert_client_initialized(session_context: SessionContext) -> EurlexClient:
     if session_context.eurlex_client is None:
-        raise ValueError("Eurlex client is not initialized")
+        # ArretifyError so the resolution step keeps going gracefully when
+        # no client is available (e.g. CI without secrets relying on dev_cache).
+        raise ArretifyError(ErrorCodes.law_data_api_error, "Eurlex client is not initialized")
     return session_context.eurlex_client

--- a/arretify/law_data/apis/legifrance.py
+++ b/arretify/law_data/apis/legifrance.py
@@ -29,7 +29,12 @@ from arretify._vendor.clients_api_droit.clients_api_droit.legifrance import (
     search_circulaire,
     search_decret,
 )
-from arretify.errors import ErrorCodes, SettingsError, catch_and_convert_into_arretify_error
+from arretify.errors import (
+    ArretifyError,
+    ErrorCodes,
+    SettingsError,
+    catch_and_convert_into_arretify_error,
+)
 from arretify.types import SessionContext
 from arretify.utils.dev_cache import use_dev_cache
 
@@ -93,5 +98,7 @@ def get_circulaire_legifrance_id(
 
 def _assert_client_initialized(session_context: SessionContext) -> LegifranceClient:
     if not session_context.legifrance_client:
-        raise ValueError("Legifrance client is not initialized")
+        # ArretifyError so the resolution step keeps going gracefully when
+        # no client is available (e.g. CI without secrets relying on dev_cache).
+        raise ArretifyError(ErrorCodes.law_data_api_error, "Legifrance client is not initialized")
     return session_context.legifrance_client

--- a/arretify/main.py
+++ b/arretify/main.py
@@ -129,25 +129,43 @@ def main(args: list[str]) -> None:
         _LOGGER.info("Mistral OCR is active")
         features = dataclass_replace(features, ocr=True)
 
-    # Initialize Legifrance client
+    # Initialize Legifrance client. In development mode, the resolution step is
+    # enabled even without a client so the dev_cache can serve previously cached
+    # results (useful for reproducible snapshots in CI without API secrets).
     try:
         session_context = initialize_legifrance_client(session_context)
     except SettingsError:
-        _LOGGER.info(
-            "Legifrance credentials not provided, skipping Legifrance references resolution"
-        )
+        if settings.env == "development":
+            _LOGGER.info(
+                "Legifrance credentials not provided, falling back to dev_cache for resolution"
+            )
+            features = dataclass_replace(features, legifrance=True)
+        else:
+            _LOGGER.info(
+                "Legifrance credentials not provided, skipping Legifrance references resolution"
+            )
     except ArretifyError as error:
         if error.code is ErrorCodes.law_data_api_error:
-            _LOGGER.warning("failed to initialize Legifrance client")
+            if settings.env == "development":
+                _LOGGER.warning("Failed to initialize Legifrance client, falling back to dev_cache")
+                features = dataclass_replace(features, legifrance=True)
+            else:
+                _LOGGER.warning("failed to initialize Legifrance client")
     else:
         _LOGGER.info("Legifrance references resolution is active")
         features = dataclass_replace(features, legifrance=True)
 
-    # Initialize Eurlex client
+    # Initialize Eurlex client. Same dev_cache fallback as for Legifrance.
     try:
         session_context = initialize_eurlex_client(session_context)
     except SettingsError:
-        _LOGGER.info("Eurlex credentials not provided, skipping Eurlex references resolution")
+        if settings.env == "development":
+            _LOGGER.info(
+                "Eurlex credentials not provided, falling back to dev_cache for resolution"
+            )
+            features = dataclass_replace(features, eurlex=True)
+        else:
+            _LOGGER.info("Eurlex credentials not provided, skipping Eurlex references resolution")
     else:
         _LOGGER.info("Eurlex references resolution is active")
         features = dataclass_replace(features, eurlex=True)

--- a/arretify/step_references_detection/match_sections_with_documents_test.py
+++ b/arretify/step_references_detection/match_sections_with_documents_test.py
@@ -259,7 +259,7 @@ class TestConnectParentSections(BaseTestCaseHtml):
             ],
         )
 
-    def test_tableau_to_article_section(self):
+    def test_table_to_article_section(self):
         # Arrange : "le tableau de l'article 1.2.1"
         self.soup_extend(
             [
@@ -300,7 +300,7 @@ class TestConnectParentSections(BaseTestCaseHtml):
             ],
         )
 
-    def test_tableau_to_article_to_document(self):
+    def test_table_to_article_to_document(self):
         # Arrange :
         # "Le tableau de l'article 1.2.1 de l'arrêté préfectoral du 23 mai 2016"
         self.soup_extend(

--- a/arretify/step_references_detection/match_sections_with_documents_test.py
+++ b/arretify/step_references_detection/match_sections_with_documents_test.py
@@ -259,6 +259,123 @@ class TestConnectParentSections(BaseTestCaseHtml):
             ],
         )
 
+    def test_tableau_to_article_section(self):
+        # Arrange : "le tableau de l'article 1.2.1"
+        self.soup_extend(
+            [
+                "le ",
+                self.make_semantic_tag(
+                    SectionReferenceSpec,
+                    contents=["tableau"],
+                ),
+                " de l' ",
+                self.make_semantic_tag(
+                    SectionReferenceSpec,
+                    contents=["article 1.2.1"],
+                ),
+            ]
+        )
+
+        # Act
+        actual = match_sections_to_parents(self.context, self.soup.contents)
+
+        # Assert
+        assert_element_lists_equal(
+            actual,
+            [
+                "le ",
+                self.make_semantic_tag(
+                    SectionReferenceSpec,
+                    contents=["tableau"],
+                    data=SectionReferenceData(
+                        parent_reference="1",
+                    ),
+                ),
+                " de l' ",
+                self.make_semantic_tag(
+                    SectionReferenceSpec,
+                    contents=["article 1.2.1"],
+                    reserved_data_attrs=dict(tag_id="1"),
+                ),
+            ],
+        )
+
+    def test_tableau_to_article_to_document(self):
+        # Arrange :
+        # "Le tableau de l'article 1.2.1 de l'arrêté préfectoral du 23 mai 2016"
+        self.soup_extend(
+            [
+                "Le ",
+                self.make_semantic_tag(
+                    SectionReferenceSpec,
+                    contents=["tableau"],
+                ),
+                " de l' ",
+                self.make_semantic_tag(
+                    SectionReferenceSpec,
+                    contents=["article 1.2.1"],
+                ),
+                " de l' ",
+                self.make_semantic_tag(
+                    DocumentReferenceSpec,
+                    contents=[
+                        "arrêté du ",
+                        self.make_semantic_tag(
+                            DateSpec,
+                            contents=["23 mai 2016"],
+                            attrs=dict(datetime="2016-05-23"),
+                        ),
+                    ],
+                    data=DocumentReferenceData(
+                        type="arrete-prefectoral",
+                    ),
+                ),
+            ]
+        )
+
+        # Act
+        actual = match_sections_to_parents(self.context, self.soup.contents)
+
+        # Assert
+        assert_element_lists_equal(
+            actual,
+            [
+                "Le ",
+                self.make_semantic_tag(
+                    SectionReferenceSpec,
+                    contents=["tableau"],
+                    data=SectionReferenceData(
+                        parent_reference="1",
+                    ),
+                ),
+                " de l' ",
+                self.make_semantic_tag(
+                    SectionReferenceSpec,
+                    contents=["article 1.2.1"],
+                    data=SectionReferenceData(
+                        parent_reference="2",
+                    ),
+                    reserved_data_attrs=dict(tag_id="1"),
+                ),
+                " de l' ",
+                self.make_semantic_tag(
+                    DocumentReferenceSpec,
+                    contents=[
+                        "arrêté du ",
+                        self.make_semantic_tag(
+                            DateSpec,
+                            contents=["23 mai 2016"],
+                            attrs=dict(datetime="2016-05-23"),
+                        ),
+                    ],
+                    data=DocumentReferenceData(
+                        type="arrete-prefectoral",
+                    ),
+                    reserved_data_attrs=dict(tag_id="2"),
+                ),
+            ],
+        )
+
     def test_section_separated_by_inline_element(self):
         # Arrange
         self.soup_extend(

--- a/arretify/step_references_detection/sections_detection.py
+++ b/arretify/step_references_detection/sections_detection.py
@@ -144,14 +144,14 @@ ALINEA_NUMBER_NODE = regex_tree.Group(
 )
 
 
-TABLEAU_NUMBER_NODE = regex_tree.Group(
+TABLE_NUMBER_NODE = regex_tree.Group(
     regex_tree.Branching(
         [
             ORDINAL_NUMBER_NODE,
             SIMPLE_NUMBER_NODE,
         ]
     ),
-    group_name="__tableau_number",
+    group_name="__table_number",
 )
 
 
@@ -246,11 +246,11 @@ def _extract_section(
     appendix_no_number_matches = filter_regex_tree_match_children(
         section_reference_match, ["__appendix_no_number"]
     )
-    tableau_matches = filter_regex_tree_match_children(
-        section_reference_match, ["__tableau_number"]
+    table_matches = filter_regex_tree_match_children(
+        section_reference_match, ["__table_number"]
     )
-    tableau_no_number_matches = filter_regex_tree_match_children(
-        section_reference_match, ["__tableau_no_number"]
+    table_no_number_matches = filter_regex_tree_match_children(
+        section_reference_match, ["__table_no_number"]
     )
 
     if (
@@ -263,8 +263,8 @@ def _extract_section(
                     unknown_section_matches,
                     appendix_matches,
                     appendix_no_number_matches,
-                    tableau_matches,
-                    tableau_no_number_matches,
+                    table_matches,
+                    table_no_number_matches,
                 ]
             ]
         )
@@ -290,10 +290,10 @@ def _extract_section(
             start_num=None,
             end_num=None,
         )
-    elif len(tableau_matches) in [1, 2]:
-        section_matches = tableau_matches
+    elif len(table_matches) in [1, 2]:
+        section_matches = table_matches
         section_type = SectionType.TABLEAU
-    elif len(tableau_no_number_matches) in [1, 2]:
+    elif len(table_no_number_matches) in [1, 2]:
         return SectionReferenceData(
             type=SectionType.TABLEAU,
             start_num=None,
@@ -433,7 +433,7 @@ SECTION_REFERENCE_NODE = regex_tree.Group(
             # - "à l'annexe"
             # - "en annexe"
             regex_tree.Group(r"annexes?", group_name="__appendix_no_number"),
-            # -------- Tableaux -------- #
+            # -------- Tables -------- #
             # Examples :
             # - "tableau 3"
             # - "tableau premier"
@@ -443,8 +443,8 @@ SECTION_REFERENCE_NODE = regex_tree.Group(
                 [
                     regex_tree.Branching(
                         [
-                            regex_tree.Sequence([TABLEAU_NUMBER_NODE, r" (tableaux?)"]),
-                            regex_tree.Sequence([r"(tableaux?) ", TABLEAU_NUMBER_NODE]),
+                            regex_tree.Sequence([TABLE_NUMBER_NODE, r" (tableaux?)"]),
+                            regex_tree.Sequence([r"(tableaux?) ", TABLE_NUMBER_NODE]),
                         ]
                     ),
                 ]
@@ -452,7 +452,7 @@ SECTION_REFERENCE_NODE = regex_tree.Group(
             # Examples :
             # - "le tableau de l'article 1.2.1"
             # - "sous le tableau de la liste"
-            regex_tree.Group(r"tableaux?", group_name="__tableau_no_number"),
+            regex_tree.Group(r"tableaux?", group_name="__table_no_number"),
         ]
     ),
     group_name="__section_reference",

--- a/arretify/step_references_detection/sections_detection.py
+++ b/arretify/step_references_detection/sections_detection.py
@@ -144,6 +144,17 @@ ALINEA_NUMBER_NODE = regex_tree.Group(
 )
 
 
+TABLEAU_NUMBER_NODE = regex_tree.Group(
+    regex_tree.Branching(
+        [
+            ORDINAL_NUMBER_NODE,
+            SIMPLE_NUMBER_NODE,
+        ]
+    ),
+    group_name="__tableau_number",
+)
+
+
 UNKNOWN_SECTION_NUMBER_NODE = regex_tree.Group(
     regex_tree.Branching(
         [
@@ -235,6 +246,12 @@ def _extract_section(
     appendix_no_number_matches = filter_regex_tree_match_children(
         section_reference_match, ["__appendix_no_number"]
     )
+    tableau_matches = filter_regex_tree_match_children(
+        section_reference_match, ["__tableau_number"]
+    )
+    tableau_no_number_matches = filter_regex_tree_match_children(
+        section_reference_match, ["__tableau_no_number"]
+    )
 
     if (
         sum(
@@ -246,6 +263,8 @@ def _extract_section(
                     unknown_section_matches,
                     appendix_matches,
                     appendix_no_number_matches,
+                    tableau_matches,
+                    tableau_no_number_matches,
                 ]
             ]
         )
@@ -268,6 +287,15 @@ def _extract_section(
     elif len(appendix_no_number_matches) in [1, 2]:
         return SectionReferenceData(
             type=SectionType.ANNEXE,
+            start_num=None,
+            end_num=None,
+        )
+    elif len(tableau_matches) in [1, 2]:
+        section_matches = tableau_matches
+        section_type = SectionType.TABLEAU
+    elif len(tableau_no_number_matches) in [1, 2]:
+        return SectionReferenceData(
+            type=SectionType.TABLEAU,
             start_num=None,
             end_num=None,
         )
@@ -405,6 +433,26 @@ SECTION_REFERENCE_NODE = regex_tree.Group(
             # - "à l'annexe"
             # - "en annexe"
             regex_tree.Group(r"annexes?", group_name="__appendix_no_number"),
+            # -------- Tableaux -------- #
+            # Examples :
+            # - "tableau 3"
+            # - "tableau premier"
+            # - "2ème tableau"
+            # - "premier tableau"
+            regex_tree.Sequence(
+                [
+                    regex_tree.Branching(
+                        [
+                            regex_tree.Sequence([TABLEAU_NUMBER_NODE, r" (tableaux?)"]),
+                            regex_tree.Sequence([r"(tableaux?) ", TABLEAU_NUMBER_NODE]),
+                        ]
+                    ),
+                ]
+            ),
+            # Examples :
+            # - "le tableau de l'article 1.2.1"
+            # - "sous le tableau de la liste"
+            regex_tree.Group(r"tableaux?", group_name="__tableau_no_number"),
         ]
     ),
     group_name="__section_reference",

--- a/arretify/step_references_detection/sections_detection.py
+++ b/arretify/step_references_detection/sections_detection.py
@@ -246,9 +246,7 @@ def _extract_section(
     appendix_no_number_matches = filter_regex_tree_match_children(
         section_reference_match, ["__appendix_no_number"]
     )
-    table_matches = filter_regex_tree_match_children(
-        section_reference_match, ["__table_number"]
-    )
+    table_matches = filter_regex_tree_match_children(section_reference_match, ["__table_number"])
     table_no_number_matches = filter_regex_tree_match_children(
         section_reference_match, ["__table_no_number"]
     )

--- a/arretify/step_references_detection/sections_detection_test.py
+++ b/arretify/step_references_detection/sections_detection_test.py
@@ -955,6 +955,144 @@ class TestUnknownMultiple(BaseTestCaseHtml):
         )
 
 
+class TestTableauSingle(BaseTestCaseHtml):
+
+    def test_tableau_num_after(self):
+        # Arrange
+        elements = ["tableau 3"]
+
+        # Act
+        actual = parse_section_references(self.context, elements)
+
+        # Assert
+        assert_element_lists_equal(
+            actual,
+            [
+                self.make_semantic_tag(
+                    SectionReferenceSpec,
+                    contents=["tableau 3"],
+                    data=SectionReferenceData(
+                        type="tableau",
+                        start_num="3",
+                    ),
+                ),
+            ],
+        )
+
+    def test_tableau_num_before(self):
+        # Arrange
+        elements = ["2ème tableau"]
+
+        # Act
+        actual = parse_section_references(self.context, elements)
+
+        # Assert
+        assert_element_lists_equal(
+            actual,
+            [
+                self.make_semantic_tag(
+                    SectionReferenceSpec,
+                    contents=["2ème tableau"],
+                    data=SectionReferenceData(
+                        type="tableau",
+                        start_num="2",
+                    ),
+                ),
+            ],
+        )
+
+    def test_tableau_ordinal_premier_before(self):
+        # Arrange
+        elements = ["le premier tableau"]
+
+        # Act
+        actual = parse_section_references(self.context, elements)
+
+        # Assert
+        assert_element_lists_equal(
+            actual,
+            [
+                "le ",
+                self.make_semantic_tag(
+                    SectionReferenceSpec,
+                    contents=["premier tableau"],
+                    data=SectionReferenceData(
+                        type="tableau",
+                        start_num="1",
+                    ),
+                ),
+            ],
+        )
+
+    def test_tableau_ordinal_after(self):
+        # Arrange
+        elements = ["tableau quatrième"]
+
+        # Act
+        actual = parse_section_references(self.context, elements)
+
+        # Assert
+        assert_element_lists_equal(
+            actual,
+            [
+                self.make_semantic_tag(
+                    SectionReferenceSpec,
+                    contents=["tableau quatrième"],
+                    data=SectionReferenceData(
+                        type="tableau",
+                        start_num="4",
+                    ),
+                ),
+            ],
+        )
+
+    def test_tableau_no_number(self):
+        # Arrange
+        elements = ["le tableau de blabla"]
+
+        # Act
+        actual = parse_section_references(self.context, elements)
+
+        # Assert
+        assert_element_lists_equal(
+            actual,
+            [
+                "le ",
+                self.make_semantic_tag(
+                    SectionReferenceSpec,
+                    contents=["tableau"],
+                    data=SectionReferenceData(
+                        type="tableau",
+                    ),
+                ),
+                " de blabla",
+            ],
+        )
+
+    def test_tableau_plural_no_number(self):
+        # Arrange
+        elements = ["sous les tableaux suivants"]
+
+        # Act
+        actual = parse_section_references(self.context, elements)
+
+        # Assert
+        assert_element_lists_equal(
+            actual,
+            [
+                "sous les ",
+                self.make_semantic_tag(
+                    SectionReferenceSpec,
+                    contents=["tableaux"],
+                    data=SectionReferenceData(
+                        type="tableau",
+                    ),
+                ),
+                " suivants",
+            ],
+        )
+
+
 class TestAppendixSingle(BaseTestCaseHtml):
 
     def test_appendix_num(self):

--- a/arretify/step_references_detection/sections_detection_test.py
+++ b/arretify/step_references_detection/sections_detection_test.py
@@ -955,9 +955,9 @@ class TestUnknownMultiple(BaseTestCaseHtml):
         )
 
 
-class TestTableauSingle(BaseTestCaseHtml):
+class TestTableSingle(BaseTestCaseHtml):
 
-    def test_tableau_num_after(self):
+    def test_table_num_after(self):
         # Arrange
         elements = ["tableau 3"]
 
@@ -979,7 +979,7 @@ class TestTableauSingle(BaseTestCaseHtml):
             ],
         )
 
-    def test_tableau_num_before(self):
+    def test_table_num_before(self):
         # Arrange
         elements = ["2ème tableau"]
 
@@ -1001,7 +1001,7 @@ class TestTableauSingle(BaseTestCaseHtml):
             ],
         )
 
-    def test_tableau_ordinal_premier_before(self):
+    def test_table_ordinal_premier_before(self):
         # Arrange
         elements = ["le premier tableau"]
 
@@ -1024,7 +1024,7 @@ class TestTableauSingle(BaseTestCaseHtml):
             ],
         )
 
-    def test_tableau_ordinal_after(self):
+    def test_table_ordinal_after(self):
         # Arrange
         elements = ["tableau quatrième"]
 
@@ -1046,7 +1046,7 @@ class TestTableauSingle(BaseTestCaseHtml):
             ],
         )
 
-    def test_tableau_no_number(self):
+    def test_table_no_number(self):
         # Arrange
         elements = ["le tableau de blabla"]
 
@@ -1069,7 +1069,7 @@ class TestTableauSingle(BaseTestCaseHtml):
             ],
         )
 
-    def test_tableau_plural_no_number(self):
+    def test_table_plural_no_number(self):
         # Arrange
         elements = ["sous les tableaux suivants"]
 

--- a/arretify/types.py
+++ b/arretify/types.py
@@ -122,6 +122,7 @@ class SectionType(Enum):
     UNKNOWN = "unknown"
     """Unknown section type. Needs context to be resolved"""
     ALINEA = "alinea"
+    TABLEAU = "tableau"
 
 
 class OperationType(Enum):

--- a/arretify/utils/dev_cache.json
+++ b/arretify/utils/dev_cache.json
@@ -160,6 +160,7 @@
         "(2007-05-07,  définissant les « normes de qualité environnementale provisoires (NQEp) » et les objectifs nationaux de réduction)": null,
         "(2009-01-05,  et téléchargeable sur le site http://rsde)": null,
         "(2010-05-10,  récapitulant les règles méthodologiques applicables aux études de dangers, à l'appréciation de la démarche de réduction)": null,
-        "(2007-01-31,  relative aux Études de dangers des dépôts de liquides inflammables – compléments à l'instruction technique du)": null
+        "(2007-01-31,  relative aux Études de dangers des dépôts de liquides inflammables – compléments à l'instruction technique du)": null,
+        "(2007-05-07, ), concentrations définies dans le)": null
     }
 }

--- a/datasets/snapshots/arretes_html/arrete_bilan_ars.html
+++ b/datasets/snapshots/arretes_html/arrete_bilan_ars.html
@@ -362,7 +362,11 @@
      Article 1er :
     </h2>
     <div data-number="1" data-spec="alinea">
-     Le bilan quantitatif de l'offre de soins de la région Grand Est est établi, pour la période de dépôt des demandes d'autorisation des activités de soins ouverte du 1er février 2025 au 1er avril 2025, conformément aux tableaux figurant en
+     Le bilan quantitatif de l'offre de soins de la région Grand Est est établi, pour la période de dépôt des demandes d'autorisation des activités de soins ouverte du 1er février 2025 au 1er avril 2025, conformément aux
+     <a data-spec="section_reference" data-type="tableau">
+      tableaux
+     </a>
+     figurant en
      <a data-parent_reference="1" data-spec="section_reference" data-type="annexe">
       annexe
      </a>

--- a/datasets/snapshots/arretes_html/arretes_icpe/0003013459/2020-04-20.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0003013459/2020-04-20.html
@@ -330,18 +330,18 @@ PRÉFET DU HAUT-RHIN
    </div>
    <div data-spec="visa">
     VU la
-    <a data-date="2010" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082" data-num="75" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082">
+    <a data-date="2010" data-num="75" data-spec="document_reference" data-type="eu-directive">
      directive 2010/75/UE
     </a>
     du 24 novembre 2010 relative aux émissions industrielles, dite « directive IED » et les conclusions sur les meilleures techniques disponibles relatives, notamment, à l’incinération de déchets (BREF « WI ») ;
    </div>
    <div data-spec="visa">
     VU la
-    <a data-date="2003" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19" data-num="87" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19">
+    <a data-date="2003" data-num="87" data-spec="document_reference" data-type="eu-directive">
      directive 2003/87/CE
     </a>
     du 13 octobre 2003 établissant un système d’échange de quotas d’émission de gaz à effet de serre dans la Communauté et modifiant la
-    <a data-date="1996" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:e81fef3f-8c7d-4683-93fc-c3bc9cacbb96" data-num="61" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:e81fef3f-8c7d-4683-93fc-c3bc9cacbb96">
+    <a data-date="1996" data-num="61" data-spec="document_reference" data-type="eu-directive">
      directive 96/61/CE
     </a>
     du Conseil ;
@@ -701,7 +701,11 @@ PRÉFET DU HAUT-RHIN
        ARTICLE 1.2.1. LISTE DES INSTALLATIONS CONCERNÉES PAR UNE RUBRIQUE DE LA NOMENCLATURE DES INSTALLATIONS CLASSÉES
       </h4>
       <div data-number="1" data-spec="alinea">
-       Les installations exploitées sont classées selon les rubriques et régimes définis dans le tableau ci-dessous :
+       Les installations exploitées sont classées selon les rubriques et régimes définis dans le
+       <a data-spec="section_reference" data-type="tableau">
+        tableau
+       </a>
+       ci-dessous :
       </div>
       <div data-number="2" data-spec="alinea">
        <table>
@@ -825,7 +829,7 @@ PRÉFET DU HAUT-RHIN
       </h4>
       <div data-number="1" data-spec="alinea">
        L'établissement possède des installations visées par la
-       <a data-date="2010" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082" data-num="75" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082">
+       <a data-date="2010" data-num="75" data-spec="document_reference" data-type="eu-directive">
         directive 2010/75/UE
        </a>
        du 24 novembre 2010 relative aux émissions industrielles, dite
@@ -2368,7 +2372,11 @@ PRÉFET DU HAUT-RHIN
        ARTICLE 3.2.3. CONDUITS ET INSTALLATIONS RACCORDÉES – CONDITIONS DE REJETS
       </h4>
       <div data-number="1" data-spec="alinea">
-       Le tableau suivant identifie les différentes émissions canalisées et fixe les conditions générales de fonctionnement :
+       Le
+       <a data-spec="section_reference" data-type="tableau">
+        tableau
+       </a>
+       suivant identifie les différentes émissions canalisées et fixe les conditions générales de fonctionnement :
       </div>
       <div data-number="2" data-spec="alinea">
        <table>
@@ -2448,7 +2456,11 @@ PRÉFET DU HAUT-RHIN
        ARTICLE 3.2.4. VALEURS LIMITES DES CONCENTRATIONS DANS LES REJETS ATMOSPHÉRIQUES – CONDUIT N°1
       </h4>
       <div data-number="1" data-spec="alinea">
-       Le tableau ci-dessous définit les valeurs limites en concentration et en flux à ne pas dépasser, les volumes de gaz rejetés étant rapportés :
+       Le
+       <a data-spec="section_reference" data-type="tableau">
+        tableau
+       </a>
+       ci-dessous définit les valeurs limites en concentration et en flux à ne pas dépasser, les volumes de gaz rejetés étant rapportés :
       </div>
       <div data-number="2" data-spec="alinea">
        <ul>
@@ -4002,7 +4014,7 @@ PRÉFET DU HAUT-RHIN
       </div>
       <div data-number="3" data-spec="alinea">
        L'importation ou l'exportation de déchets ne peut être réalisée qu'après accord des autorités compétentes en application du
-       <a data-date="2006" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:1784c89a-69e5-43eb-9c40-1157f6895e85" data-num="1013" data-spec="document_reference" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:1784c89a-69e5-43eb-9c40-1157f6895e85">
+       <a data-date="2006" data-num="1013" data-spec="document_reference" data-type="eu-regulation">
         règlement (CE) n° 1013/2006
        </a>
        du Parlement européen et du Conseil du 14 juin 2006 concernant les transferts de déchets.
@@ -4262,7 +4274,7 @@ PRÉFET DU HAUT-RHIN
       </h4>
       <div data-number="1" data-spec="alinea">
        L'inventaire et l'état des stocks des substances et mélanges susceptibles d'être présents dans l'établissement (nature, état physique, quantité, emplacement) est tenu à jour et à disposition de l'inspection des installations classées et des services d'incendie et de secours (a minima les substances et mélanges dangereux selon le
-       <a data-date="2008" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:6bf54b59-7673-461b-b8e1-f24c545cbd3c" data-num="1272" data-spec="document_reference" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:6bf54b59-7673-461b-b8e1-f24c545cbd3c">
+       <a data-date="2008" data-num="1272" data-spec="document_reference" data-type="eu-regulation">
         règlement 1272/2008
        </a>
        , dit CLP).
@@ -4277,7 +4289,7 @@ PRÉFET DU HAUT-RHIN
       </h4>
       <div data-number="1" data-spec="alinea">
        Les fûts, réservoirs et autres emballages portent en caractères très lisibles le nom des substances et mélanges, et s'il y a lieu, les éléments d'étiquetage conformément au
-       <a data-date="2008" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:6bf54b59-7673-461b-b8e1-f24c545cbd3c" data-num="1272" data-spec="document_reference" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:6bf54b59-7673-461b-b8e1-f24c545cbd3c">
+       <a data-date="2008" data-num="1272" data-spec="document_reference" data-type="eu-regulation">
         règlement n°1272/2008
        </a>
        dit CLP ou le cas échéant par la réglementation sectorielle applicable aux produits considérés.
@@ -4397,7 +4409,11 @@ PRÉFET DU HAUT-RHIN
        ARTICLE 7.2.1. VALEURS LIMITES D'ÉMERGENCE
       </h4>
       <div data-number="1" data-spec="alinea">
-       Les émissions sonores dues aux activités des installations ne doivent pas engendrer une émergence supérieure aux valeurs admissibles fixées dans le tableau suivant dans les zones à émergence réglementée, définies conformément à l'
+       Les émissions sonores dues aux activités des installations ne doivent pas engendrer une émergence supérieure aux valeurs admissibles fixées dans le
+       <a data-spec="section_reference" data-type="tableau">
+        tableau
+       </a>
+       suivant dans les zones à émergence réglementée, définies conformément à l'
        <a data-date="1997-01-23" data-spec="document_reference" data-type="arrete">
         arrêté du
         <time data-spec="date" datetime="1997-01-23">
@@ -4845,7 +4861,7 @@ PRÉFET DU HAUT-RHIN
       </div>
       <div data-number="2" data-spec="alinea">
        Les appareils et systèmes de protection destinés à être utilisés dans les emplacements où des atmosphères explosives, peuvent se présenter doivent être sélectionnés conformément aux catégories prévues par la
-       <a data-date="2014" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:68451154-b720-11e3-86f9-01aa75ed71a1" data-num="34" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:68451154-b720-11e3-86f9-01aa75ed71a1">
+       <a data-date="2014" data-num="34" data-spec="document_reference" data-type="eu-directive">
         directive 2014/34/UE
        </a>
        , sauf dispositions contraires prévues dans l'étude de dangers, sur la base d'une évaluation des risques correspondante.
@@ -7088,12 +7104,16 @@ PRÉFET DU HAUT-RHIN
        ARTICLE 10.5.1. AUTORISATION D'ÉMETTRE DES GAZ À EFFET DE SERRE
       </h4>
       <div data-number="1" data-spec="alinea">
-       La présente installation est soumise au système d'échange de quotas de gaz à effet de serre car elle exerce les activités suivantes, listées au tableau de l'
-       <a data-parent_reference="62" data-spec="section_reference" data-start_num="R229-5" data-type="article" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+       La présente installation est soumise au système d'échange de quotas de gaz à effet de serre car elle exerce les activités suivantes, listées au
+       <a data-parent_reference="62" data-spec="section_reference" data-type="tableau" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+        tableau
+       </a>
+       de l'
+       <a data-parent_reference="63" data-spec="section_reference" data-start_num="R229-5" data-tag_id="62" data-type="article" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
         article R229-5
        </a>
        du
-       <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="62" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+       <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="63" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
         code de l'environnement
        </a>
        :
@@ -7132,15 +7152,15 @@ PRÉFET DU HAUT-RHIN
       </div>
       <div data-number="3" data-spec="alinea">
        Cette autorisation d'exploiter vaut autorisation d'émettre des gaz à effet de serre prévue à l'
-       <a data-parent_reference="63" data-spec="section_reference" data-start_id="LEGIARTI000049572860" data-start_num="L229-6" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049572860">
+       <a data-parent_reference="64" data-spec="section_reference" data-start_id="LEGIARTI000049572860" data-start_num="L229-6" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049572860">
         article L.229-6
        </a>
        du
-       <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="63" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+       <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="64" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
         code de l'environnement
        </a>
        au titre de la
-       <a data-date="2003" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19" data-num="87" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19">
+       <a data-date="2003" data-num="87" data-spec="document_reference" data-type="eu-directive">
         Directive 2003/87/CE
        </a>
        .
@@ -7158,11 +7178,11 @@ PRÉFET DU HAUT-RHIN
       </h4>
       <div data-number="1" data-spec="alinea">
        L'exploitant surveille ses émissions de gaz à effet de serre sur la base d'un plan de surveillance conforme au
-       <a data-date="2012" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d" data-num="601" data-spec="document_reference" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d">
+       <a data-date="2012" data-num="601" data-spec="document_reference" data-type="eu-regulation">
         règlement n° 601/2012
        </a>
        du 21 juin 2012 relatif à la surveillance et à la déclaration des émissions de gaz à effet de serre au titre de la
-       <a data-date="2003" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19" data-num="87" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19">
+       <a data-date="2003" data-num="87" data-spec="document_reference" data-type="eu-directive">
         directive 2003/87/CE
        </a>
        du Parlement européen et du Conseil. Le plan de surveillance est transmis au préfet pour approbation avant la mise en service de l'installation.
@@ -7172,29 +7192,29 @@ PRÉFET DU HAUT-RHIN
       </div>
       <div data-number="3" data-spec="alinea">
        Le Préfet peut demander à l'exploitant de modifier sa méthode de surveillance si les méthodes de surveillance ne sont plus conformes au
-       <a data-date="2012" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d" data-num="601" data-spec="document_reference" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d">
+       <a data-date="2012" data-num="601" data-spec="document_reference" data-type="eu-regulation">
         règlement 601/2012
        </a>
        relatif à la surveillance et à la déclaration des émissions de gaz à effet de serre.
       </div>
       <div data-number="4" data-spec="alinea">
        L'exploitant vérifie régulièrement que le plan de surveillance est adapté à la nature et au fonctionnement de l'installation et étudie la nécessité d'une amélioration de la méthode de surveillance. Il modifie le plan de surveillance dans les cas mentionnés à l'
-       <a data-parent_reference="64" data-spec="section_reference" data-start_num="14" data-type="article">
+       <a data-parent_reference="65" data-spec="section_reference" data-start_num="14" data-type="article">
         article 14
        </a>
        du
-       <a data-date="2012" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d" data-num="601" data-spec="document_reference" data-tag_id="64" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d">
+       <a data-date="2012" data-num="601" data-spec="document_reference" data-tag_id="65" data-type="eu-regulation">
         règlement 601/2012
        </a>
        relatif à la surveillance et à la déclaration des émissions de gaz à effet de serre.
       </div>
       <div data-number="5" data-spec="alinea">
        L'exploitant notifie au préfet toute modification de son plan de surveillance. Les modifications importantes, notamment celles listées à l'
-       <a data-parent_reference="65" data-spec="section_reference" data-start_num="15" data-type="article">
+       <a data-parent_reference="66" data-spec="section_reference" data-start_num="15" data-type="article">
         article 15
        </a>
        du
-       <a data-date="2012" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d" data-num="601" data-spec="document_reference" data-tag_id="65" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d">
+       <a data-date="2012" data-num="601" data-spec="document_reference" data-tag_id="66" data-type="eu-regulation">
         règlement 601/2012
        </a>
        , sont transmises pour approbation au Préfet dans les meilleurs délais. Les autres sont portées à la connaissance du Préfet avant le 31 décembre de l'année.
@@ -7206,11 +7226,11 @@ PRÉFET DU HAUT-RHIN
       </h4>
       <div data-number="1" data-spec="alinea">
        Conformément à l'
-       <a data-parent_reference="66" data-spec="section_reference" data-start_id="LEGIARTI000049732026" data-start_num="R229-20" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049732026">
+       <a data-parent_reference="67" data-spec="section_reference" data-start_id="LEGIARTI000049732026" data-start_num="R229-20" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049732026">
         article R.229-20
        </a>
        du
-       <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="66" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+       <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="67" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
         code de l'environnement
        </a>
        , l'exploitant adresse au plus tard le 28 février de chaque année, la déclaration des émissions de gaz à effet de serre de l'année précédente, vérifiée par un organisme accrédité à cet effet. La déclaration des émissions est vérifiée conformément au
@@ -7218,7 +7238,7 @@ PRÉFET DU HAUT-RHIN
         règlement 2018/2067
        </a>
        concernant la vérification des données et l'accréditation des vérificateurs conformément à la
-       <a data-date="2003" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19" data-num="87" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19">
+       <a data-date="2003" data-num="87" data-spec="document_reference" data-type="eu-directive">
         directive 2003/87/CE
        </a>
        . Le rapport du vérificateur est joint à la déclaration.
@@ -7237,11 +7257,11 @@ PRÉFET DU HAUT-RHIN
       </h4>
       <div data-number="1" data-spec="alinea">
        Conformément à l'
-       <a data-parent_reference="67" data-spec="section_reference" data-start_id="LEGIARTI000049731940" data-start_num="R229-21" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049731940">
+       <a data-parent_reference="68" data-spec="section_reference" data-start_id="LEGIARTI000049731940" data-start_num="R229-21" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049731940">
         article R.229-21
        </a>
        du
-       <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="67" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+       <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="68" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
         code de l'environnement
        </a>
        , l'exploitant restitue au plus tard le 30 avril de chaque année un nombre de quotas correspondant aux émissions vérifiées totales de son installation au cours de l'année précédente.
@@ -7349,11 +7369,11 @@ PRÉFET DU HAUT-RHIN
      </div>
      <div data-number="8" data-spec="alinea">
       (
-      <a data-parent_reference="68" data-spec="section_reference" data-start_id="LEGIARTI000049531386" data-start_num="R181-50" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049531386">
+      <a data-parent_reference="69" data-spec="section_reference" data-start_id="LEGIARTI000049531386" data-start_num="R181-50" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049531386">
        article R. 181-50
       </a>
       du
-      <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="68" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+      <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="69" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
        Code de l’environnement
       </a>
       ).

--- a/datasets/snapshots/arretes_html/arretes_icpe/0003013459/2020-04-20.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0003013459/2020-04-20.html
@@ -330,18 +330,18 @@ PRÉFET DU HAUT-RHIN
    </div>
    <div data-spec="visa">
     VU la
-    <a data-date="2010" data-num="75" data-spec="document_reference" data-type="eu-directive">
+    <a data-date="2010" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082" data-num="75" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082">
      directive 2010/75/UE
     </a>
     du 24 novembre 2010 relative aux émissions industrielles, dite « directive IED » et les conclusions sur les meilleures techniques disponibles relatives, notamment, à l’incinération de déchets (BREF « WI ») ;
    </div>
    <div data-spec="visa">
     VU la
-    <a data-date="2003" data-num="87" data-spec="document_reference" data-type="eu-directive">
+    <a data-date="2003" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19" data-num="87" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19">
      directive 2003/87/CE
     </a>
     du 13 octobre 2003 établissant un système d’échange de quotas d’émission de gaz à effet de serre dans la Communauté et modifiant la
-    <a data-date="1996" data-num="61" data-spec="document_reference" data-type="eu-directive">
+    <a data-date="1996" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:e81fef3f-8c7d-4683-93fc-c3bc9cacbb96" data-num="61" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:e81fef3f-8c7d-4683-93fc-c3bc9cacbb96">
      directive 96/61/CE
     </a>
     du Conseil ;
@@ -464,7 +464,7 @@ PRÉFET DU HAUT-RHIN
    </div>
    <div data-spec="visa">
     VU l'
-    <a data-date="2014-04-28" data-id="JORFTEXT000028931114" data-spec="document_reference" data-type="arrete-ministeriel" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000028931114">
+    <a data-date="2014-04-28" data-spec="document_reference" data-type="arrete-ministeriel">
      arrêté ministériel du
      <time data-spec="date" datetime="2014-04-28">
       28 avril 2014
@@ -829,7 +829,7 @@ PRÉFET DU HAUT-RHIN
       </h4>
       <div data-number="1" data-spec="alinea">
        L'établissement possède des installations visées par la
-       <a data-date="2010" data-num="75" data-spec="document_reference" data-type="eu-directive">
+       <a data-date="2010" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082" data-num="75" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082">
         directive 2010/75/UE
        </a>
        du 24 novembre 2010 relative aux émissions industrielles, dite
@@ -1376,7 +1376,7 @@ PRÉFET DU HAUT-RHIN
         </li>
         <li>
          -
-         <a data-date="1998-02-02" data-id="JORFTEXT000000204891" data-spec="document_reference" data-type="arrete-ministeriel" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000000204891">
+         <a data-date="1998-02-02" data-spec="document_reference" data-type="arrete-ministeriel">
           arrêté ministériel du
           <time data-spec="date" datetime="1998-02-02">
            02 février 1998
@@ -4289,7 +4289,7 @@ PRÉFET DU HAUT-RHIN
       </h4>
       <div data-number="1" data-spec="alinea">
        Les fûts, réservoirs et autres emballages portent en caractères très lisibles le nom des substances et mélanges, et s'il y a lieu, les éléments d'étiquetage conformément au
-       <a data-date="2008" data-num="1272" data-spec="document_reference" data-type="eu-regulation">
+       <a data-date="2008" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:6bf54b59-7673-461b-b8e1-f24c545cbd3c" data-num="1272" data-spec="document_reference" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:6bf54b59-7673-461b-b8e1-f24c545cbd3c">
         règlement n°1272/2008
        </a>
        dit CLP ou le cas échéant par la réglementation sectorielle applicable aux produits considérés.
@@ -4861,7 +4861,7 @@ PRÉFET DU HAUT-RHIN
       </div>
       <div data-number="2" data-spec="alinea">
        Les appareils et systèmes de protection destinés à être utilisés dans les emplacements où des atmosphères explosives, peuvent se présenter doivent être sélectionnés conformément aux catégories prévues par la
-       <a data-date="2014" data-num="34" data-spec="document_reference" data-type="eu-directive">
+       <a data-date="2014" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:68451154-b720-11e3-86f9-01aa75ed71a1" data-num="34" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:68451154-b720-11e3-86f9-01aa75ed71a1">
         directive 2014/34/UE
        </a>
        , sauf dispositions contraires prévues dans l'étude de dangers, sur la base d'une évaluation des risques correspondante.
@@ -7160,7 +7160,7 @@ PRÉFET DU HAUT-RHIN
         code de l'environnement
        </a>
        au titre de la
-       <a data-date="2003" data-num="87" data-spec="document_reference" data-type="eu-directive">
+       <a data-date="2003" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19" data-num="87" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19">
         Directive 2003/87/CE
        </a>
        .
@@ -7203,7 +7203,7 @@ PRÉFET DU HAUT-RHIN
         article 14
        </a>
        du
-       <a data-date="2012" data-num="601" data-spec="document_reference" data-tag_id="65" data-type="eu-regulation">
+       <a data-date="2012" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d" data-num="601" data-spec="document_reference" data-tag_id="65" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d">
         règlement 601/2012
        </a>
        relatif à la surveillance et à la déclaration des émissions de gaz à effet de serre.
@@ -7214,7 +7214,7 @@ PRÉFET DU HAUT-RHIN
         article 15
        </a>
        du
-       <a data-date="2012" data-num="601" data-spec="document_reference" data-tag_id="66" data-type="eu-regulation">
+       <a data-date="2012" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d" data-num="601" data-spec="document_reference" data-tag_id="66" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d">
         règlement 601/2012
        </a>
        , sont transmises pour approbation au Préfet dans les meilleurs délais. Les autres sont portées à la connaissance du Préfet avant le 31 décembre de l'année.

--- a/datasets/snapshots/arretes_html/arretes_icpe/0003013459/2020-04-20.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0003013459/2020-04-20.html
@@ -464,7 +464,7 @@ PRÉFET DU HAUT-RHIN
    </div>
    <div data-spec="visa">
     VU l'
-    <a data-date="2014-04-28" data-spec="document_reference" data-type="arrete-ministeriel">
+    <a data-date="2014-04-28" data-id="JORFTEXT000028931114" data-spec="document_reference" data-type="arrete-ministeriel" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000028931114">
      arrêté ministériel du
      <time data-spec="date" datetime="2014-04-28">
       28 avril 2014
@@ -1376,7 +1376,7 @@ PRÉFET DU HAUT-RHIN
         </li>
         <li>
          -
-         <a data-date="1998-02-02" data-spec="document_reference" data-type="arrete-ministeriel">
+         <a data-date="1998-02-02" data-id="JORFTEXT000000204891" data-spec="document_reference" data-type="arrete-ministeriel" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000000204891">
           arrêté ministériel du
           <time data-spec="date" datetime="1998-02-02">
            02 février 1998
@@ -4014,7 +4014,7 @@ PRÉFET DU HAUT-RHIN
       </div>
       <div data-number="3" data-spec="alinea">
        L'importation ou l'exportation de déchets ne peut être réalisée qu'après accord des autorités compétentes en application du
-       <a data-date="2006" data-num="1013" data-spec="document_reference" data-type="eu-regulation">
+       <a data-date="2006" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:1784c89a-69e5-43eb-9c40-1157f6895e85" data-num="1013" data-spec="document_reference" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:1784c89a-69e5-43eb-9c40-1157f6895e85">
         règlement (CE) n° 1013/2006
        </a>
        du Parlement européen et du Conseil du 14 juin 2006 concernant les transferts de déchets.
@@ -4274,7 +4274,7 @@ PRÉFET DU HAUT-RHIN
       </h4>
       <div data-number="1" data-spec="alinea">
        L'inventaire et l'état des stocks des substances et mélanges susceptibles d'être présents dans l'établissement (nature, état physique, quantité, emplacement) est tenu à jour et à disposition de l'inspection des installations classées et des services d'incendie et de secours (a minima les substances et mélanges dangereux selon le
-       <a data-date="2008" data-num="1272" data-spec="document_reference" data-type="eu-regulation">
+       <a data-date="2008" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:6bf54b59-7673-461b-b8e1-f24c545cbd3c" data-num="1272" data-spec="document_reference" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:6bf54b59-7673-461b-b8e1-f24c545cbd3c">
         règlement 1272/2008
        </a>
        , dit CLP).
@@ -7178,11 +7178,11 @@ PRÉFET DU HAUT-RHIN
       </h4>
       <div data-number="1" data-spec="alinea">
        L'exploitant surveille ses émissions de gaz à effet de serre sur la base d'un plan de surveillance conforme au
-       <a data-date="2012" data-num="601" data-spec="document_reference" data-type="eu-regulation">
+       <a data-date="2012" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d" data-num="601" data-spec="document_reference" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d">
         règlement n° 601/2012
        </a>
        du 21 juin 2012 relatif à la surveillance et à la déclaration des émissions de gaz à effet de serre au titre de la
-       <a data-date="2003" data-num="87" data-spec="document_reference" data-type="eu-directive">
+       <a data-date="2003" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19" data-num="87" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19">
         directive 2003/87/CE
        </a>
        du Parlement européen et du Conseil. Le plan de surveillance est transmis au préfet pour approbation avant la mise en service de l'installation.
@@ -7192,7 +7192,7 @@ PRÉFET DU HAUT-RHIN
       </div>
       <div data-number="3" data-spec="alinea">
        Le Préfet peut demander à l'exploitant de modifier sa méthode de surveillance si les méthodes de surveillance ne sont plus conformes au
-       <a data-date="2012" data-num="601" data-spec="document_reference" data-type="eu-regulation">
+       <a data-date="2012" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d" data-num="601" data-spec="document_reference" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d">
         règlement 601/2012
        </a>
        relatif à la surveillance et à la déclaration des émissions de gaz à effet de serre.
@@ -7238,7 +7238,7 @@ PRÉFET DU HAUT-RHIN
         règlement 2018/2067
        </a>
        concernant la vérification des données et l'accréditation des vérificateurs conformément à la
-       <a data-date="2003" data-num="87" data-spec="document_reference" data-type="eu-directive">
+       <a data-date="2003" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19" data-num="87" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19">
         directive 2003/87/CE
        </a>
        . Le rapport du vérificateur est joint à la déclaration.

--- a/datasets/snapshots/arretes_html/arretes_icpe/0003013459/2021-09-24.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0003013459/2021-09-24.html
@@ -343,11 +343,11 @@ Fraternité
    </div>
    <div data-spec="visa">
     VU la
-    <a data-date="2003" data-num="87" data-spec="document_reference" data-type="eu-directive">
+    <a data-date="2003" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19" data-num="87" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19">
      directive 2003/87/CE
     </a>
     du 13 octobre 2003 établissant un système d'échange de quotas d'émission de gaz à effet de serre dans la Communauté et modifiant la
-    <a data-date="1996" data-num="61" data-spec="document_reference" data-type="eu-directive">
+    <a data-date="1996" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:e81fef3f-8c7d-4683-93fc-c3bc9cacbb96" data-num="61" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:e81fef3f-8c7d-4683-93fc-c3bc9cacbb96">
      directive 96/61/CE
     </a>
     du Conseil ;
@@ -855,7 +855,7 @@ Fraternité
       </h4>
       <div data-number="1" data-spec="alinea">
        L'établissement possède des installations visées par la
-       <a data-date="2010" data-num="75" data-spec="document_reference" data-type="eu-directive">
+       <a data-date="2010" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082" data-num="75" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082">
         directive 2010/75/UE
        </a>
        du 24 novembre 2010 relative aux émissions industrielles, dite
@@ -4291,7 +4291,7 @@ Fraternité
       </h4>
       <div data-number="1" data-spec="alinea">
        Les fûts, réservoirs et autre emballages portent en caractères très lisibles le nom des substances et mélanges, et s'il y a lieu, les éléments d'étiquetage conformément au
-       <a data-date="2008" data-num="1272" data-spec="document_reference" data-type="eu-regulation">
+       <a data-date="2008" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:6bf54b59-7673-461b-b8e1-f24c545cbd3c" data-num="1272" data-spec="document_reference" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:6bf54b59-7673-461b-b8e1-f24c545cbd3c">
         règlement n° 1272/2008
        </a>
        dit CLP ou le cas échéant par la réglementation sectorielle applicable aux produits considérés.
@@ -4861,7 +4861,7 @@ Fraternité
       </div>
       <div data-number="2" data-spec="alinea">
        Les appareils et systèmes de protection destinés à être utilisés dans les emplacements où des atmosphères explosives, peuvent se présenter doivent être sélectionnés conformément aux catégories prévues par la
-       <a data-date="2014" data-num="34" data-spec="document_reference" data-type="eu-directive">
+       <a data-date="2014" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:68451154-b720-11e3-86f9-01aa75ed71a1" data-num="34" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:68451154-b720-11e3-86f9-01aa75ed71a1">
         directive 2014/34/UE
        </a>
        , sauf dispositions contraires prévues dans l'étude de dangers, sur la base d'une évaluation des risques correspondante.
@@ -7242,7 +7242,7 @@ Fraternité
         article 14
        </a>
        du
-       <a data-date="2012" data-num="601" data-spec="document_reference" data-tag_id="64" data-type="eu-regulation">
+       <a data-date="2012" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d" data-num="601" data-spec="document_reference" data-tag_id="64" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d">
         règlement 601/2012
        </a>
        relatif à la surveillance et à la déclaration des émissions de gaz à effet de serre.
@@ -7253,7 +7253,7 @@ Fraternité
         article 15
        </a>
        du
-       <a data-date="2012" data-num="601" data-spec="document_reference" data-tag_id="65" data-type="eu-regulation">
+       <a data-date="2012" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d" data-num="601" data-spec="document_reference" data-tag_id="65" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d">
         règlement 601/2012
        </a>
        , sont transmises pour approbation au Préfet dans les meilleurs délais. Les autres sont portées à la connaissance du Préfet avant le 31 décembre de l'année.
@@ -7273,7 +7273,7 @@ Fraternité
         règlement 2018/2067
        </a>
        concernant la vérification des données et l'accréditation des vérificateurs conformément à la
-       <a data-date="2003" data-num="87" data-spec="document_reference" data-type="eu-directive">
+       <a data-date="2003" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19" data-num="87" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19">
         directive 2003/87/CE
        </a>
        . Le rapport du vérificateur est joint à la déclaration.

--- a/datasets/snapshots/arretes_html/arretes_icpe/0003013459/2021-09-24.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0003013459/2021-09-24.html
@@ -336,7 +336,7 @@ Fraternité
    </div>
    <div data-spec="visa">
     VU la
-    <a data-date="2010" data-num="75" data-spec="document_reference" data-type="eu-directive">
+    <a data-date="2010" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082" data-num="75" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082">
      directive 2010/75/UE
     </a>
     du 24 novembre 2010 relative aux émissions industrielles, dite « directive IED » et les conclusions sur les meilleures techniques disponibles relatives, notamment, à l'incinération de déchets (BREF « WI ») ;
@@ -4012,7 +4012,7 @@ Fraternité
       </div>
       <div data-number="3" data-spec="alinea">
        L'importation ou l'exportation de déchets ne peut être réalisée qu'après accord des autorités compétentes en application du
-       <a data-date="2006" data-num="1013" data-spec="document_reference" data-type="eu-regulation">
+       <a data-date="2006" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:1784c89a-69e5-43eb-9c40-1157f6895e85" data-num="1013" data-spec="document_reference" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:1784c89a-69e5-43eb-9c40-1157f6895e85">
         règlement (CE) n° 1013/2006
        </a>
        du Parlement européen et du Conseil du 14 juin 2006 concernant les transferts de déchets.
@@ -4269,7 +4269,7 @@ Fraternité
       </h4>
       <div data-number="1" data-spec="alinea">
        L'inventaire et l'état des stocks des substances et mélanges susceptibles d'être présents dans l'établissement (nature, état physique, quantité, emplacement) est tenu à jour et à disposition de l'inspection des installations classées et des services d'incendie et de secours (a minima les substances et mélanges dangereux selon le
-       <a data-date="2008" data-num="1272" data-spec="document_reference" data-type="eu-regulation">
+       <a data-date="2008" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:6bf54b59-7673-461b-b8e1-f24c545cbd3c" data-num="1272" data-spec="document_reference" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:6bf54b59-7673-461b-b8e1-f24c545cbd3c">
         règlement 1272/2008
        </a>
        , dit CLP).
@@ -7197,7 +7197,7 @@ Fraternité
         code de l'environnement
        </a>
        au titre de la
-       <a data-date="2003" data-num="87" data-spec="document_reference" data-type="eu-directive">
+       <a data-date="2003" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19" data-num="87" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19">
         Directive 2003/87/CE
        </a>
        .
@@ -7217,11 +7217,11 @@ Fraternité
       </h4>
       <div data-number="1" data-spec="alinea">
        L'exploitant surveille ses émissions de gaz à effet de serre sur la base d'un plan de surveillance conforme au
-       <a data-date="2012" data-num="601" data-spec="document_reference" data-type="eu-regulation">
+       <a data-date="2012" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d" data-num="601" data-spec="document_reference" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d">
         règlement n° 601/2012
        </a>
        du 21 juin 2012 relatif à la surveillance et à la déclaration des émissions de gaz à effet de serre au titre de la
-       <a data-date="2003" data-num="87" data-spec="document_reference" data-type="eu-directive">
+       <a data-date="2003" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19" data-num="87" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19">
         directive 2003/87/CE
        </a>
        du Parlement européen et du Conseil. Le plan de surveillance est transmis au préfet pour approbation avant la mise en service de l'installation.
@@ -7231,7 +7231,7 @@ Fraternité
       </div>
       <div data-number="3" data-spec="alinea">
        Le Préfet peut demander à l'exploitant de modifier sa méthode de surveillance si les méthodes de surveillance ne sont plus conformes au
-       <a data-date="2012" data-num="601" data-spec="document_reference" data-type="eu-regulation">
+       <a data-date="2012" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d" data-num="601" data-spec="document_reference" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d">
         règlement 601/2012
        </a>
        relatif à la surveillance et à la déclaration des émissions de gaz à effet de serre.

--- a/datasets/snapshots/arretes_html/arretes_icpe/0003013459/2021-09-24.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0003013459/2021-09-24.html
@@ -336,18 +336,18 @@ Fraternité
    </div>
    <div data-spec="visa">
     VU la
-    <a data-date="2010" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082" data-num="75" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082">
+    <a data-date="2010" data-num="75" data-spec="document_reference" data-type="eu-directive">
      directive 2010/75/UE
     </a>
     du 24 novembre 2010 relative aux émissions industrielles, dite « directive IED » et les conclusions sur les meilleures techniques disponibles relatives, notamment, à l'incinération de déchets (BREF « WI ») ;
    </div>
    <div data-spec="visa">
     VU la
-    <a data-date="2003" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19" data-num="87" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19">
+    <a data-date="2003" data-num="87" data-spec="document_reference" data-type="eu-directive">
      directive 2003/87/CE
     </a>
     du 13 octobre 2003 établissant un système d'échange de quotas d'émission de gaz à effet de serre dans la Communauté et modifiant la
-    <a data-date="1996" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:e81fef3f-8c7d-4683-93fc-c3bc9cacbb96" data-num="61" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:e81fef3f-8c7d-4683-93fc-c3bc9cacbb96">
+    <a data-date="1996" data-num="61" data-spec="document_reference" data-type="eu-directive">
      directive 96/61/CE
     </a>
     du Conseil ;
@@ -665,13 +665,13 @@ Fraternité
       </h4>
       <div data-number="1" data-spec="alinea">
        Les prescriptions de l'
-       <a data-date="2020-04-20" data-spec="document_reference" data-tag_id="67" data-type="arrete-prefectoral">
+       <a data-date="2020-04-20" data-spec="document_reference" data-tag_id="68" data-type="arrete-prefectoral">
         arrêté préfectoral du
         <time data-spec="date" datetime="2020-04-20">
          20 avril 2020
         </time>
        </a>
-       <span data-direction="rtl" data-has_operand="true" data-keyword="remplacées" data-operation_type="replace" data-references="67" data-spec="operation">
+       <span data-direction="rtl" data-has_operand="true" data-keyword="remplacées" data-operation_type="replace" data-references="68" data-spec="operation">
         sont
         <b>
          remplacées
@@ -723,7 +723,11 @@ Fraternité
        Article 1.2.1. Liste des installations concernées par une rubrique de la nomenclature des installations classées
       </h4>
       <div data-number="1" data-spec="alinea">
-       Les installations exploitées sont classées selon les rubriques et régimes définis dans le tableau ci-dessous :
+       Les installations exploitées sont classées selon les rubriques et régimes définis dans le
+       <a data-spec="section_reference" data-type="tableau">
+        tableau
+       </a>
+       ci-dessous :
       </div>
       <div data-number="2" data-spec="alinea">
        <table>
@@ -851,7 +855,7 @@ Fraternité
       </h4>
       <div data-number="1" data-spec="alinea">
        L'établissement possède des installations visées par la
-       <a data-date="2010" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082" data-num="75" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082">
+       <a data-date="2010" data-num="75" data-spec="document_reference" data-type="eu-directive">
         directive 2010/75/UE
        </a>
        du 24 novembre 2010 relative aux émissions industrielles, dite
@@ -2400,7 +2404,11 @@ Fraternité
        Article 3.2.3. Conduits et installations raccordées – conditions de rejets
       </h4>
       <div data-number="1" data-spec="alinea">
-       Le tableau suivant identifie les différentes émissions canalisées et fixe les conditions générales de fonctionnement :
+       Le
+       <a data-spec="section_reference" data-type="tableau">
+        tableau
+       </a>
+       suivant identifie les différentes émissions canalisées et fixe les conditions générales de fonctionnement :
       </div>
       <div data-number="2" data-spec="alinea">
        <table>
@@ -2480,7 +2488,11 @@ Fraternité
        Article 3.2.4. Valeurs limites des concentrations dans les rejets atmosphériques – Conduit n°1
       </h4>
       <div data-number="1" data-spec="alinea">
-       Le tableau ci-dessous définit les valeurs limites en concentration et en flux à ne pas dépasser, les volumes de gaz rejetés étant rapportés :
+       Le
+       <a data-spec="section_reference" data-type="tableau">
+        tableau
+       </a>
+       ci-dessous définit les valeurs limites en concentration et en flux à ne pas dépasser, les volumes de gaz rejetés étant rapportés :
       </div>
       <div data-number="2" data-spec="alinea">
        <ul>
@@ -4000,7 +4012,7 @@ Fraternité
       </div>
       <div data-number="3" data-spec="alinea">
        L'importation ou l'exportation de déchets ne peut être réalisée qu'après accord des autorités compétentes en application du
-       <a data-date="2006" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:1784c89a-69e5-43eb-9c40-1157f6895e85" data-num="1013" data-spec="document_reference" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:1784c89a-69e5-43eb-9c40-1157f6895e85">
+       <a data-date="2006" data-num="1013" data-spec="document_reference" data-type="eu-regulation">
         règlement (CE) n° 1013/2006
        </a>
        du Parlement européen et du Conseil du 14 juin 2006 concernant les transferts de déchets.
@@ -4257,7 +4269,7 @@ Fraternité
       </h4>
       <div data-number="1" data-spec="alinea">
        L'inventaire et l'état des stocks des substances et mélanges susceptibles d'être présents dans l'établissement (nature, état physique, quantité, emplacement) est tenu à jour et à disposition de l'inspection des installations classées et des services d'incendie et de secours (a minima les substances et mélanges dangereux selon le
-       <a data-date="2008" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:6bf54b59-7673-461b-b8e1-f24c545cbd3c" data-num="1272" data-spec="document_reference" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:6bf54b59-7673-461b-b8e1-f24c545cbd3c">
+       <a data-date="2008" data-num="1272" data-spec="document_reference" data-type="eu-regulation">
         règlement 1272/2008
        </a>
        , dit CLP).
@@ -4279,7 +4291,7 @@ Fraternité
       </h4>
       <div data-number="1" data-spec="alinea">
        Les fûts, réservoirs et autre emballages portent en caractères très lisibles le nom des substances et mélanges, et s'il y a lieu, les éléments d'étiquetage conformément au
-       <a data-date="2008" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:6bf54b59-7673-461b-b8e1-f24c545cbd3c" data-num="1272" data-spec="document_reference" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:6bf54b59-7673-461b-b8e1-f24c545cbd3c">
+       <a data-date="2008" data-num="1272" data-spec="document_reference" data-type="eu-regulation">
         règlement n° 1272/2008
        </a>
        dit CLP ou le cas échéant par la réglementation sectorielle applicable aux produits considérés.
@@ -4399,7 +4411,11 @@ Fraternité
        Article 7.2.1. Valeurs limites d'émergence
       </h4>
       <div data-number="1" data-spec="alinea">
-       Les émissions sonores dues aux activités des installations ne doivent pas engendrer une émergence supérieure aux valeurs admissibles fixées dans le tableau suivant dans les zones à émergence réglementée, définies conformément à l'
+       Les émissions sonores dues aux activités des installations ne doivent pas engendrer une émergence supérieure aux valeurs admissibles fixées dans le
+       <a data-spec="section_reference" data-type="tableau">
+        tableau
+       </a>
+       suivant dans les zones à émergence réglementée, définies conformément à l'
        <a data-date="1997-01-23" data-spec="document_reference" data-type="arrete">
         arrêté du
         <time data-spec="date" datetime="1997-01-23">
@@ -4845,7 +4861,7 @@ Fraternité
       </div>
       <div data-number="2" data-spec="alinea">
        Les appareils et systèmes de protection destinés à être utilisés dans les emplacements où des atmosphères explosives, peuvent se présenter doivent être sélectionnés conformément aux catégories prévues par la
-       <a data-date="2014" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:68451154-b720-11e3-86f9-01aa75ed71a1" data-num="34" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:68451154-b720-11e3-86f9-01aa75ed71a1">
+       <a data-date="2014" data-num="34" data-spec="document_reference" data-type="eu-directive">
         directive 2014/34/UE
        </a>
        , sauf dispositions contraires prévues dans l'étude de dangers, sur la base d'une évaluation des risques correspondante.
@@ -7125,12 +7141,16 @@ Fraternité
        Article 10.5.1. Autorisation d'émettre des gaz à effet de serre
       </h4>
       <div data-number="1" data-spec="alinea">
-       La présente installation est soumise au système d'échange de quotas de gaz à effet de serre car elle exerce les activités suivantes, listées au tableau de l'
-       <a data-parent_reference="61" data-spec="section_reference" data-start_num="R229-5" data-type="article" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+       La présente installation est soumise au système d'échange de quotas de gaz à effet de serre car elle exerce les activités suivantes, listées au
+       <a data-parent_reference="61" data-spec="section_reference" data-type="tableau" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+        tableau
+       </a>
+       de l'
+       <a data-parent_reference="62" data-spec="section_reference" data-start_num="R229-5" data-tag_id="61" data-type="article" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
         article R.229-5
        </a>
        du
-       <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="61" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+       <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="62" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
         code de l'environnement
        </a>
        :
@@ -7169,15 +7189,15 @@ Fraternité
       </div>
       <div data-number="3" data-spec="alinea">
        Cette autorisation d'exploiter vaut autorisation d'émettre des gaz à effet de serre, prévue à l'
-       <a data-parent_reference="62" data-spec="section_reference" data-start_id="LEGIARTI000049572860" data-start_num="L229-6" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049572860">
+       <a data-parent_reference="63" data-spec="section_reference" data-start_id="LEGIARTI000049572860" data-start_num="L229-6" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049572860">
         article L.229-6
        </a>
        du
-       <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="62" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+       <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="63" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
         code de l'environnement
        </a>
        au titre de la
-       <a data-date="2003" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19" data-num="87" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19">
+       <a data-date="2003" data-num="87" data-spec="document_reference" data-type="eu-directive">
         Directive 2003/87/CE
        </a>
        .
@@ -7197,11 +7217,11 @@ Fraternité
       </h4>
       <div data-number="1" data-spec="alinea">
        L'exploitant surveille ses émissions de gaz à effet de serre sur la base d'un plan de surveillance conforme au
-       <a data-date="2012" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d" data-num="601" data-spec="document_reference" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d">
+       <a data-date="2012" data-num="601" data-spec="document_reference" data-type="eu-regulation">
         règlement n° 601/2012
        </a>
        du 21 juin 2012 relatif à la surveillance et à la déclaration des émissions de gaz à effet de serre au titre de la
-       <a data-date="2003" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19" data-num="87" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19">
+       <a data-date="2003" data-num="87" data-spec="document_reference" data-type="eu-directive">
         directive 2003/87/CE
        </a>
        du Parlement européen et du Conseil. Le plan de surveillance est transmis au préfet pour approbation avant la mise en service de l'installation.
@@ -7211,29 +7231,29 @@ Fraternité
       </div>
       <div data-number="3" data-spec="alinea">
        Le Préfet peut demander à l'exploitant de modifier sa méthode de surveillance si les méthodes de surveillance ne sont plus conformes au
-       <a data-date="2012" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d" data-num="601" data-spec="document_reference" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d">
+       <a data-date="2012" data-num="601" data-spec="document_reference" data-type="eu-regulation">
         règlement 601/2012
        </a>
        relatif à la surveillance et à la déclaration des émissions de gaz à effet de serre.
       </div>
       <div data-number="4" data-spec="alinea">
        L'exploitant vérifie régulièrement que le plan de surveillance est adapté à la nature et au fonctionnement de l'installation et étudie la nécessité d'une amélioration de la méthode de surveillance. Il modifie le plan de surveillance dans les cas mentionnés à l'
-       <a data-parent_reference="63" data-spec="section_reference" data-start_num="14" data-type="article">
+       <a data-parent_reference="64" data-spec="section_reference" data-start_num="14" data-type="article">
         article 14
        </a>
        du
-       <a data-date="2012" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d" data-num="601" data-spec="document_reference" data-tag_id="63" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d">
+       <a data-date="2012" data-num="601" data-spec="document_reference" data-tag_id="64" data-type="eu-regulation">
         règlement 601/2012
        </a>
        relatif à la surveillance et à la déclaration des émissions de gaz à effet de serre.
       </div>
       <div data-number="5" data-spec="alinea">
        L'exploitant notifie au préfet toute modification de son plan de surveillance. Les modifications importantes, notamment celles listées à l'
-       <a data-parent_reference="64" data-spec="section_reference" data-start_num="15" data-type="article">
+       <a data-parent_reference="65" data-spec="section_reference" data-start_num="15" data-type="article">
         article 15
        </a>
        du
-       <a data-date="2012" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d" data-num="601" data-spec="document_reference" data-tag_id="64" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:a025c83e-c7f9-4f94-87bb-3522f4ff930d">
+       <a data-date="2012" data-num="601" data-spec="document_reference" data-tag_id="65" data-type="eu-regulation">
         règlement 601/2012
        </a>
        , sont transmises pour approbation au Préfet dans les meilleurs délais. Les autres sont portées à la connaissance du Préfet avant le 31 décembre de l'année.
@@ -7253,7 +7273,7 @@ Fraternité
         règlement 2018/2067
        </a>
        concernant la vérification des données et l'accréditation des vérificateurs conformément à la
-       <a data-date="2003" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19" data-num="87" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19">
+       <a data-date="2003" data-num="87" data-spec="document_reference" data-type="eu-directive">
         directive 2003/87/CE
        </a>
        . Le rapport du vérificateur est joint à la déclaration.
@@ -7265,11 +7285,11 @@ Fraternité
       </h4>
       <div data-number="1" data-spec="alinea">
        Conformément à l'
-       <a data-parent_reference="65" data-spec="section_reference" data-start_id="LEGIARTI000049731940" data-start_num="R229-21" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049731940">
+       <a data-parent_reference="66" data-spec="section_reference" data-start_id="LEGIARTI000049731940" data-start_num="R229-21" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049731940">
         article R.229-21
        </a>
        du
-       <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="65" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+       <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="66" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
         code de l'environnement
        </a>
        , l'exploitant restitue au plus tard le 30 avril de chaque année un nombre de quotas correspondant aux émissions vérifiées totales de son installation au cours de l'année précédente.
@@ -7372,11 +7392,11 @@ Fraternité
      </div>
      <div data-number="9" data-spec="alinea">
       (
-      <a data-parent_reference="66" data-spec="section_reference" data-start_id="LEGIARTI000049531386" data-start_num="R181-50" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049531386">
+      <a data-parent_reference="67" data-spec="section_reference" data-start_id="LEGIARTI000049531386" data-start_num="R181-50" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049531386">
        article R. 181-50
       </a>
       du
-      <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="66" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+      <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="67" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
        Code de l'environnement
       </a>
       ).

--- a/datasets/snapshots/arretes_html/arretes_icpe/0003013459/2023-02-22.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0003013459/2023-02-22.html
@@ -336,18 +336,18 @@ Fraternité
    </div>
    <div data-spec="visa">
     VU la
-    <a data-date="2010" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082" data-num="75" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082">
+    <a data-date="2010" data-num="75" data-spec="document_reference" data-type="eu-directive">
      directive 2010/75/UE
     </a>
     du 24 novembre 2010 relative aux émissions industrielles, dite « directive IED » et les conclusions sur les meilleures techniques disponibles relatives, notamment, à l'incinération de déchets (BREF « WI ») ;
    </div>
    <div data-spec="visa">
     VU la
-    <a data-date="2003" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19" data-num="87" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19">
+    <a data-date="2003" data-num="87" data-spec="document_reference" data-type="eu-directive">
      directive 2003/87/CE
     </a>
     du 13 octobre 2003 établissant un système d'échange de quotas d'émission de gaz à effet de serre dans la Communauté et modifiant la
-    <a data-date="1996" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:e81fef3f-8c7d-4683-93fc-c3bc9cacbb96" data-num="61" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:e81fef3f-8c7d-4683-93fc-c3bc9cacbb96">
+    <a data-date="1996" data-num="61" data-spec="document_reference" data-type="eu-directive">
      directive 96/61/CE
     </a>
     du Conseil ;
@@ -598,7 +598,11 @@ Fraternité
     <div data-number="2" data-spec="alinea">
      <blockquote data-tag_id="12">
       <p>
-       Les installations exploitées sont classées selon les rubriques et régimes définis dans le tableau ci-dessous :
+       Les installations exploitées sont classées selon les rubriques et régimes définis dans le
+       <a data-spec="section_reference" data-type="tableau">
+        tableau
+       </a>
+       ci-dessous :
       </p>
       <table>
        <tr>

--- a/datasets/snapshots/arretes_html/arretes_icpe/0003013459/2023-02-22.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0003013459/2023-02-22.html
@@ -336,7 +336,7 @@ Fraternité
    </div>
    <div data-spec="visa">
     VU la
-    <a data-date="2010" data-num="75" data-spec="document_reference" data-type="eu-directive">
+    <a data-date="2010" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082" data-num="75" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082">
      directive 2010/75/UE
     </a>
     du 24 novembre 2010 relative aux émissions industrielles, dite « directive IED » et les conclusions sur les meilleures techniques disponibles relatives, notamment, à l'incinération de déchets (BREF « WI ») ;

--- a/datasets/snapshots/arretes_html/arretes_icpe/0003013459/2023-02-22.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0003013459/2023-02-22.html
@@ -343,11 +343,11 @@ Fraternité
    </div>
    <div data-spec="visa">
     VU la
-    <a data-date="2003" data-num="87" data-spec="document_reference" data-type="eu-directive">
+    <a data-date="2003" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19" data-num="87" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:518d47fe-bb29-4eac-a25e-42d0499f4e19">
      directive 2003/87/CE
     </a>
     du 13 octobre 2003 établissant un système d'échange de quotas d'émission de gaz à effet de serre dans la Communauté et modifiant la
-    <a data-date="1996" data-num="61" data-spec="document_reference" data-type="eu-directive">
+    <a data-date="1996" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:e81fef3f-8c7d-4683-93fc-c3bc9cacbb96" data-num="61" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:e81fef3f-8c7d-4683-93fc-c3bc9cacbb96">
      directive 96/61/CE
     </a>
     du Conseil ;

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005302394/2008-12-10.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005302394/2008-12-10.html
@@ -2502,7 +2502,11 @@ RÉPUBLIQUE FRANÇAISE
          - à des conditions normalisées de température (273 kelvins) et de pression (101,3 kilo pascals) après déduction de la vapeur d'eau (gaz secs) ;
         </li>
         <li>
-         - à une teneur en O₂ ou CO₂ précisée dans le tableau ci-dessous.
+         - à une teneur en O₂ ou CO₂ précisée dans le
+         <a data-spec="section_reference" data-type="tableau">
+          tableau
+         </a>
+         ci-dessous.
         </li>
        </ul>
       </div>
@@ -3655,7 +3659,11 @@ RÉPUBLIQUE FRANÇAISE
        L'émergence est définie comme étant la différence entre les niveaux de pression continus équivalents pondérés A du bruit ambiant (mesurés lorsque l'établissement est en fonctionnement) et les niveaux sonores correspondant au bruit résiduel (établissement à l'arrêt).
       </div>
       <div data-number="2" data-spec="alinea">
-       Les émissions sonores dues aux activités des installations ne doivent pas engendrer une émergence supérieure aux valeurs limites admissibles fixées dans le tableau ci-après, dans les zones à émergence réglementée.
+       Les émissions sonores dues aux activités des installations ne doivent pas engendrer une émergence supérieure aux valeurs limites admissibles fixées dans le
+       <a data-spec="section_reference" data-type="tableau">
+        tableau
+       </a>
+       ci-après, dans les zones à émergence réglementée.
       </div>
       <div data-number="3" data-spec="alinea">
        <table>
@@ -5627,7 +5635,11 @@ RÉPUBLIQUE FRANÇAISE
         Ces contrôles périodiques doivent être réalisés durant les périodes de fonctionnement normal des installations contrôlées. Sur demande de l'exploitant ou de sa propre initiative, l'inspection des installations classées pourra modifier la fréquence des analyses à pratiquer et/ou la nature des paramètres à rechercher au vu des résultats présentés.
        </div>
        <div data-number="2" data-spec="alinea">
-        Ces résultats sont reportés par l'exploitant sur un registre tenu à disposition de l'Inspection des installations Classées et archivés pendant au moins trois ans. Un état récapitulatif des analyses et mesures effectuées en application du présent article est transmis à l'inspection des installations classées, tous les ans sous une forme synthétique accompagnée de commentaires expliquant les dépassements constatés, leur durée ainsi que les dispositions prises afin d'y remédier et qu'ils ne puissent se reproduire. Cet état comprend pour chaque exutoire et pour chaque paramètre figurant dans les tableaux précédents :
+        Ces résultats sont reportés par l'exploitant sur un registre tenu à disposition de l'Inspection des installations Classées et archivés pendant au moins trois ans. Un état récapitulatif des analyses et mesures effectuées en application du présent article est transmis à l'inspection des installations classées, tous les ans sous une forme synthétique accompagnée de commentaires expliquant les dépassements constatés, leur durée ainsi que les dispositions prises afin d'y remédier et qu'ils ne puissent se reproduire. Cet état comprend pour chaque exutoire et pour chaque paramètre figurant dans les
+        <a data-spec="section_reference" data-type="tableau">
+         tableaux
+        </a>
+        précédents :
        </div>
        <div data-number="3" data-spec="alinea">
         <ul>
@@ -5897,10 +5909,18 @@ RÉPUBLIQUE FRANÇAISE
         Les systèmes de contrôle déclenchent, sans délai, une alarme sonore signalant le rejet d'effluents non conformes aux limites de pH et entraînent automatiquement l'arrêt immédiat de ces rejets.
        </div>
        <div data-number="9" data-spec="alinea">
-        Pour les polluants repris dans le tableau ci-après, les mesures du niveau des rejets sont réalisées sur un échantillon représentatif de l'émission journalière. Les mesures doivent permettre une estimation du niveau des rejets par rapport aux valeurs limites d'émission fixées.
+        Pour les polluants repris dans le
+        <a data-spec="section_reference" data-type="tableau">
+         tableau
+        </a>
+        ci-après, les mesures du niveau des rejets sont réalisées sur un échantillon représentatif de l'émission journalière. Les mesures doivent permettre une estimation du niveau des rejets par rapport aux valeurs limites d'émission fixées.
        </div>
        <div data-number="10" data-spec="alinea">
-        Ces mesures sont effectuées à minima suivant les fréquences et les méthodes définies dans le tableau ci-après :
+        Ces mesures sont effectuées à minima suivant les fréquences et les méthodes définies dans le
+        <a data-spec="section_reference" data-type="tableau">
+         tableau
+        </a>
+        ci-après :
        </div>
        <div data-number="11" data-spec="alinea">
         <table>
@@ -5997,7 +6017,11 @@ RÉPUBLIQUE FRANÇAISE
         sont archivés pendant au moins cinq ans, sur un support prévu à cet effet, et sont tenus à la disposition de l'inspection des installations classées. Ils doivent être répertoriés pour pouvoir être corrélés avec les dates de rejet.
        </div>
        <div data-number="2" data-spec="alinea">
-        Un état récapitulatif des analyses et mesures effectuées est transmis à l'inspection des installations classées, tous les mois, sous une forme synthétique. Cet état comprend le volume hebdomadaire prélevé, le volume journalier rejeté en sortie station, et pour chaque paramètre figurant dans les tableaux précédents, sa concentration et son flux en fonction de la périodicité retenue et les résultats des mesures comparatives le cas échéant. L'état comprend également les concentrations minimale et maximale du mois, les flux minimal, maximal et moyen du mois et le flux total rejeté durant le mois.
+        Un état récapitulatif des analyses et mesures effectuées est transmis à l'inspection des installations classées, tous les mois, sous une forme synthétique. Cet état comprend le volume hebdomadaire prélevé, le volume journalier rejeté en sortie station, et pour chaque paramètre figurant dans les
+        <a data-spec="section_reference" data-type="tableau">
+         tableaux
+        </a>
+        précédents, sa concentration et son flux en fonction de la périodicité retenue et les résultats des mesures comparatives le cas échéant. L'état comprend également les concentrations minimale et maximale du mois, les flux minimal, maximal et moyen du mois et le flux total rejeté durant le mois.
        </div>
        <div data-number="3" data-spec="alinea">
         Ce document est accompagné de commentaires expliquant les dépassements constatés, leur durée ainsi que les dispositions prises afin d'y remédier et pour qu'ils ne puissent se reproduire.

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005302394/2010-12-24.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005302394/2010-12-24.html
@@ -295,14 +295,14 @@ RÉPUBLIQUE FRANÇAISE
    </div>
    <div data-spec="visa">
     VU la
-    <a data-date="2006" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374" data-num="11" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374">
+    <a data-date="2006" data-num="11" data-spec="document_reference" data-type="eu-directive">
      directive européenne 2006/11/CE
     </a>
     concernant la pollution causée par certaines substances dangereuses déversées dans le milieu aquatique de la Communauté ;
    </div>
    <div data-spec="visa">
     VU la
-    <a data-date="2000" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb" data-num="60" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb">
+    <a data-date="2000" data-num="60" data-spec="document_reference" data-type="eu-directive">
      directive européenne 2000/60/CE
     </a>
     du 23 octobre 2000 établissant un cadre pour une politique communautaire dans le domaine de l’eau (DCE) ;
@@ -501,7 +501,7 @@ Tout courrier relatif à cette affaire, doit obligatoirement être adressé sous
    </div>
    <div data-spec="motifs">
     Considérant l'objectif de respect des normes de qualité environnementale dans le milieu en 2015 fixé par la
-    <a data-date="2000" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb" data-num="60" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb">
+    <a data-date="2000" data-num="60" data-spec="document_reference" data-type="eu-directive">
      directive européenne 2000/60/CE
     </a>
     ;
@@ -649,7 +649,11 @@ Tout courrier relatif à cette affaire, doit obligatoirement être adressé sous
       2. Liste de références en matière d’opérations de prélèvements de substances dangereuses dans les rejets industriels ;
      </div>
      <div data-number="6" data-spec="alinea">
-      3. Tableau des performances et d’assurance qualité précisant les limites de quantification pour l’analyse des substances qui doivent être inférieures ou égales à celles de l’
+      3.
+      <a data-spec="section_reference" data-type="tableau">
+       Tableau
+      </a>
+      des performances et d’assurance qualité précisant les limites de quantification pour l’analyse des substances qui doivent être inférieures ou égales à celles de l’
       <a data-parent_reference="7" data-spec="section_reference" data-start_num="2" data-type="annexe">
        annexe 2
       </a>
@@ -809,7 +813,11 @@ Tout courrier relatif à cette affaire, doit obligatoirement être adressé sous
      <div data-number="2" data-spec="alinea">
       <ul>
        <li>
-        - un tableau récapitulatif des mesures sous une forme synthétique selon l'
+        - un
+        <a data-spec="section_reference" data-type="tableau">
+         tableau
+        </a>
+        récapitulatif des mesures sous une forme synthétique selon l'
         <a data-parent_reference="14" data-spec="section_reference" data-start_num="4" data-type="annexe">
          annexe 4
         </a>
@@ -817,7 +825,15 @@ Tout courrier relatif à cette affaire, doit obligatoirement être adressé sous
         <a data-spec="document_reference" data-tag_id="14" data-type="self">
          présent arrêté
         </a>
-        . Ce tableau comprend, pour chaque substance, sa concentration et son flux, pour chacune des mesures réalisées. Le tableau comprend également les concentrations minimale, maximale et moyenne mesurées sur l'ensemble des mesures, ainsi que les flux minimal, maximal et moyen calculés à partir de l'ensemble de ces mesures et les limites de quantification pour chaque mesure ;
+        . Ce
+        <a data-spec="section_reference" data-type="tableau">
+         tableau
+        </a>
+        comprend, pour chaque substance, sa concentration et son flux, pour chacune des mesures réalisées. Le
+        <a data-spec="section_reference" data-type="tableau">
+         tableau
+        </a>
+        comprend également les concentrations minimale, maximale et moyenne mesurées sur l'ensemble des mesures, ainsi que les flux minimal, maximal et moyen calculés à partir de l'ensemble de ces mesures et les limites de quantification pour chaque mesure ;
        </li>
        <li>
         - l'ensemble des rapports d'analyses réalisées en application du
@@ -872,15 +888,23 @@ Tout courrier relatif à cette affaire, doit obligatoirement être adressé sous
       1. Il est clairement établi que ce sont les eaux amont qui sont responsables de la présence de la substance dans les rejets de l'établissement ;
      </div>
      <div data-number="3" data-spec="alinea">
-      2. Toutes les concentrations mesurées pour la substance sont strictement inférieures à la limite de quantification LQ définie dans le tableau de l'
-      <a data-parent_reference="17" data-spec="section_reference" data-start_num="1" data-type="annexe">
+      2. Toutes les concentrations mesurées pour la substance sont strictement inférieures à la limite de quantification LQ définie dans le
+      <a data-parent_reference="17" data-spec="section_reference" data-type="tableau">
+       tableau
+      </a>
+      de l'
+      <a data-parent_reference="18" data-spec="section_reference" data-start_num="1" data-tag_id="17" data-type="annexe">
        annexe 1
       </a>
       du
-      <a data-spec="document_reference" data-tag_id="17" data-type="self">
+      <a data-spec="document_reference" data-tag_id="18" data-type="self">
        présent arrêté
       </a>
-      (4ème colonne du tableau);
+      (4ème colonne du
+      <a data-spec="section_reference" data-type="tableau">
+       tableau
+      </a>
+      );
      </div>
      <div data-number="4" data-spec="alinea">
       3. 3.1 Toutes les concentrations mesurées pour la substance sont inférieures à 10*NQE (norme de qualité environnementale fixées dans l'
@@ -891,19 +915,19 @@ Tout courrier relatif à cette affaire, doit obligatoirement être adressé sous
        </time>
       </a>
       relatif aux méthodes et critères d'évaluation de l'état écologique, de l'état chimique et du potentiel écologique des eaux de surface pris en application des
-      <a data-group_id="2" data-parent_reference="18" data-spec="section_reference" data-start_id="LEGIARTI000037474764" data-start_num="R212-10" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037474764">
+      <a data-group_id="2" data-parent_reference="19" data-spec="section_reference" data-start_id="LEGIARTI000037474764" data-start_num="R212-10" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037474764">
        articles R. 212-10
       </a>
       ,
-      <a data-group_id="2" data-parent_reference="18" data-spec="section_reference" data-start_id="LEGIARTI000037474771" data-start_num="R212-11" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037474771">
+      <a data-group_id="2" data-parent_reference="19" data-spec="section_reference" data-start_id="LEGIARTI000037474771" data-start_num="R212-11" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037474771">
        R.212-11
       </a>
       et
-      <a data-group_id="2" data-parent_reference="18" data-spec="section_reference" data-start_id="LEGIARTI000006836824" data-start_num="R212-18" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006836824">
+      <a data-group_id="2" data-parent_reference="19" data-spec="section_reference" data-start_id="LEGIARTI000006836824" data-start_num="R212-18" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006836824">
        R.212-18
       </a>
       du
-      <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="18" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+      <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="19" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
        code de l'environnement
       </a>
       ou, en l'attente de leur adoption en droit français, 10*NQEp, norme de qualité environnementale provisoire fixée dans la
@@ -913,15 +937,23 @@ Tout courrier relatif à cette affaire, doit obligatoirement être adressé sous
         7 mai 2007
        </time>
       </a>
-      ), concentrations définies dans le tableau de l'
-      <a data-parent_reference="19" data-spec="section_reference" data-start_num="1" data-type="annexe">
+      ), concentrations définies dans le
+      <a data-parent_reference="20" data-spec="section_reference" data-type="tableau">
+       tableau
+      </a>
+      de l'
+      <a data-parent_reference="21" data-spec="section_reference" data-start_num="1" data-tag_id="20" data-type="annexe">
        annexe 1
       </a>
       du
-      <a data-spec="document_reference" data-tag_id="19" data-type="self">
+      <a data-spec="document_reference" data-tag_id="21" data-type="self">
        présent arrêté
       </a>
-      (5ème colonne du tableau);
+      (5ème colonne du
+      <a data-spec="section_reference" data-type="tableau">
+       tableau
+      </a>
+      );
      </div>
      <div data-number="5" data-spec="alinea">
       ET 3.2 Tous les flux journaliers calculés pour la substance sont inférieurs à 10% du flux journalier théorique admissible par le milieu récepteur (le flux journalier admissible étant calculé à partir du produit du débit mensuel d'étiage de fréquence quinquennale sèche QMNA5 (0,065 m3/s) et de la NQE ou NQEp conformément aux explications de l’alinéa précédent).
@@ -953,22 +985,22 @@ Tout courrier relatif à cette affaire, doit obligatoirement être adressé sous
         article 3
        </a>
        ainsi que les éléments relatifs au contexte de la mesure analytique des substances figurant à l'
-       <a data-parent_reference="20" data-spec="section_reference" data-start_num="2" data-type="annexe">
+       <a data-parent_reference="22" data-spec="section_reference" data-start_num="2" data-type="annexe">
         annexe 2
        </a>
        du
-       <a data-spec="document_reference" data-tag_id="20" data-type="self">
+       <a data-spec="document_reference" data-tag_id="22" data-type="self">
         présent arrêté
        </a>
        .
       </li>
       <li>
        - De transmettre mensuellement à l'INERIS par le biais du site http://rsde.ineris.fr les éléments relatifs au contexte de la mesure analytique des substances figurant en
-       <a data-parent_reference="21" data-spec="section_reference" data-start_num="2" data-type="annexe">
+       <a data-parent_reference="23" data-spec="section_reference" data-start_num="2" data-type="annexe">
         annexe 2
        </a>
        du
-       <a data-spec="document_reference" data-tag_id="21" data-type="self">
+       <a data-spec="document_reference" data-tag_id="23" data-type="self">
         présent arrêté
        </a>
        .
@@ -1123,11 +1155,11 @@ Tout courrier relatif à cette affaire, doit obligatoirement être adressé sous
         LQ en μg/l
         <br/>
         (source :
-        <a data-parent_reference="22" data-spec="section_reference" data-start_num="5.2" data-type="annexe">
+        <a data-parent_reference="24" data-spec="section_reference" data-start_num="5.2" data-type="annexe">
          annexe 5.2
         </a>
         de la
-        <a data-date="2009-01-05" data-spec="document_reference" data-tag_id="22" data-type="circulaire">
+        <a data-date="2009-01-05" data-spec="document_reference" data-tag_id="24" data-type="circulaire">
          circulaire du
          <time data-spec="date" datetime="2009-01-05">
           05/01/2009
@@ -1455,11 +1487,11 @@ Tout courrier relatif à cette affaire, doit obligatoirement être adressé sous
     </a>
     <div data-number="10" data-spec="alinea">
      (documents disponibles à l'
-     <a data-parent_reference="23" data-spec="section_reference" data-start_num="5.5" data-type="annexe">
+     <a data-parent_reference="25" data-spec="section_reference" data-start_num="5.5" data-type="annexe">
       annexe 5.5
      </a>
      de la
-     <a data-date="2009-01-05" data-spec="document_reference" data-tag_id="23" data-type="circulaire">
+     <a data-date="2009-01-05" data-spec="document_reference" data-tag_id="25" data-type="circulaire">
       circulaire du
       <time data-spec="date" datetime="2009-01-05">
        5 janvier 2009
@@ -3469,11 +3501,11 @@ VU pour être annexé à mon arrêté en date de 1er jour. 2010
     </h2>
     <div data-number="1" data-spec="alinea">
      (Document disponible à l'
-     <a data-parent_reference="24" data-spec="section_reference" data-start_num="5.4" data-type="annexe">
+     <a data-parent_reference="26" data-spec="section_reference" data-start_num="5.4" data-type="annexe">
       annexe 5.4
      </a>
      de la
-     <a data-date="2009-01-05" data-spec="document_reference" data-tag_id="24" data-type="circulaire">
+     <a data-date="2009-01-05" data-spec="document_reference" data-tag_id="26" data-type="circulaire">
       circulaire du
       <time data-spec="date" datetime="2009-01-05">
        5 janvier 2009
@@ -6607,8 +6639,12 @@ VU pour être annexé à mon arrêté en date de 1er jour. 2010
       <a data-spec="section_reference" data-start_num="10" data-type="annexe">
        annexe X
       </a>
-      de la DCE (tableau A de la
-      <a data-date="2007-05-07" data-spec="document_reference" data-type="circulaire">
+      de la DCE (
+      <a data-parent_reference="27" data-spec="section_reference" data-type="tableau">
+       tableau
+      </a>
+      A de la
+      <a data-date="2007-05-07" data-spec="document_reference" data-tag_id="27" data-type="circulaire">
        circulaire du
        <time data-spec="date" datetime="2007-05-07">
         07/05/07
@@ -6621,8 +6657,12 @@ VU pour être annexé à mon arrêté en date de 1er jour. 2010
       <a data-spec="section_reference" data-start_num="10" data-type="annexe">
        annexe X
       </a>
-      de la DCE (tableau A de la
-      <a data-date="2007-05-07" data-spec="document_reference" data-type="circulaire">
+      de la DCE (
+      <a data-parent_reference="28" data-spec="section_reference" data-type="tableau">
+       tableau
+      </a>
+      A de la
+      <a data-date="2007-05-07" data-spec="document_reference" data-tag_id="28" data-type="circulaire">
        circulaire du
        <time data-spec="date" datetime="2007-05-07">
         07/05/07
@@ -6632,19 +6672,23 @@ VU pour être annexé à mon arrêté en date de 1er jour. 2010
      </div>
      <div data-number="6" data-spec="alinea">
       ☐ Autres substances pertinentes issues de la liste I de la
-      <a data-date="2006" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374" data-num="11" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374">
+      <a data-date="2006" data-num="11" data-spec="document_reference" data-type="eu-directive">
        directive 2006/11/CE
       </a>
       (anciennement
-      <a data-date="1976" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:2efc093a-eba8-4834-8ae6-c91d6c47db78" data-num="464" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:2efc093a-eba8-4834-8ae6-c91d6c47db78">
+      <a data-date="1976" data-num="464" data-spec="document_reference" data-type="eu-directive">
        Directive 76/464/CEE
       </a>
       ) et ne figurant pas à l'
       <a data-spec="section_reference" data-start_num="10" data-type="annexe">
        annexe X
       </a>
-      de la DCE (tableau B de la
-      <a data-date="2007-05-07" data-spec="document_reference" data-type="circulaire">
+      de la DCE (
+      <a data-parent_reference="29" data-spec="section_reference" data-type="tableau">
+       tableau
+      </a>
+      B de la
+      <a data-date="2007-05-07" data-spec="document_reference" data-tag_id="29" data-type="circulaire">
        circulaire du
        <time data-spec="date" datetime="2007-05-07">
         07/05/07
@@ -6654,15 +6698,19 @@ VU pour être annexé à mon arrêté en date de 1er jour. 2010
      </div>
      <div data-number="7" data-spec="alinea">
       ☐ Autres substances pertinentes issues de la liste II de la
-      <a data-date="2006" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374" data-num="11" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374">
+      <a data-date="2006" data-num="11" data-spec="document_reference" data-type="eu-directive">
        directive 2006/11/CE
       </a>
       (anciennement
-      <a data-date="1976" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:2efc093a-eba8-4834-8ae6-c91d6c47db78" data-num="464" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:2efc093a-eba8-4834-8ae6-c91d6c47db78">
+      <a data-date="1976" data-num="464" data-spec="document_reference" data-type="eu-directive">
        Directive 76/464/CEE
       </a>
-      ) et autres substances, non SDP ni SP (tableaux D et E de la
-      <a data-date="2007-05-07" data-spec="document_reference" data-type="circulaire">
+      ) et autres substances, non SDP ni SP (
+      <a data-parent_reference="30" data-spec="section_reference" data-type="tableau">
+       tableaux
+      </a>
+      D et E de la
+      <a data-date="2007-05-07" data-spec="document_reference" data-tag_id="30" data-type="circulaire">
        circulaire du
        <time data-spec="date" datetime="2007-05-07">
         07/05/07
@@ -6686,7 +6734,7 @@ VU pour être annexé à mon arrêté en date de 1er jour. 2010
         annexe X
        </a>
        de la DCE (
-       <a data-date="2000" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb" data-num="60" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb">
+       <a data-date="2000" data-num="60" data-spec="document_reference" data-type="eu-directive">
         Directive 2000/60/CE
        </a>
        ).
@@ -9311,7 +9359,15 @@ VU pour être annexé à mon arrêté en date de 1er jour. 2010
        2. Liste de références en matière d’opérations de prélèvements de substances dangereuses dans les rejets industriels
       </h4>
       <div data-number="1" data-spec="alinea">
-       3. Tableau des performances et d’assurance qualité à renseigner obligatoirement : les critères de choix pour l’exploitant pour la sélection d’un laboratoire prestataire sont repris dans ce tableau : substance accréditée ou non, et limite de quantification qui doivent être inférieures ou égales aux LQ de l’
+       3.
+       <a data-spec="section_reference" data-type="tableau">
+        Tableau
+       </a>
+       des performances et d’assurance qualité à renseigner obligatoirement : les critères de choix pour l’exploitant pour la sélection d’un laboratoire prestataire sont repris dans ce
+       <a data-spec="section_reference" data-type="tableau">
+        tableau
+       </a>
+       : substance accréditée ou non, et limite de quantification qui doivent être inférieures ou égales aux LQ de l’
        <a data-spec="section_reference" data-start_num="5.2" data-type="annexe">
         annexe 5.2.
        </a>
@@ -9334,7 +9390,10 @@ VU pour être annexé à mon arrêté en date de 1er jour. 2010
        </div>
       </div>
       <div data-number="1" data-spec="alinea">
-       TABLEAU DES PERFORMANCES ET ASSURANCE QUALITÉ
+       <a data-spec="section_reference" data-type="tableau">
+        TABLEAU
+       </a>
+       DES PERFORMANCES ET ASSURANCE QUALITÉ
       </div>
       <div data-number="2" data-spec="alinea">
        A RENSEIGNER ET À RESTITUER A L'EXPLOITANT

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005302394/2010-12-24.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005302394/2010-12-24.html
@@ -6702,7 +6702,7 @@ VU pour être annexé à mon arrêté en date de 1er jour. 2010
        directive 2006/11/CE
       </a>
       (anciennement
-      <a data-date="1976" data-num="464" data-spec="document_reference" data-type="eu-directive">
+      <a data-date="1976" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:2efc093a-eba8-4834-8ae6-c91d6c47db78" data-num="464" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:2efc093a-eba8-4834-8ae6-c91d6c47db78">
        Directive 76/464/CEE
       </a>
       ) et autres substances, non SDP ni SP (

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005302394/2010-12-24.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005302394/2010-12-24.html
@@ -295,14 +295,14 @@ RÉPUBLIQUE FRANÇAISE
    </div>
    <div data-spec="visa">
     VU la
-    <a data-date="2006" data-num="11" data-spec="document_reference" data-type="eu-directive">
+    <a data-date="2006" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374" data-num="11" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374">
      directive européenne 2006/11/CE
     </a>
     concernant la pollution causée par certaines substances dangereuses déversées dans le milieu aquatique de la Communauté ;
    </div>
    <div data-spec="visa">
     VU la
-    <a data-date="2000" data-num="60" data-spec="document_reference" data-type="eu-directive">
+    <a data-date="2000" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb" data-num="60" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb">
      directive européenne 2000/60/CE
     </a>
     du 23 octobre 2000 établissant un cadre pour une politique communautaire dans le domaine de l’eau (DCE) ;
@@ -501,7 +501,7 @@ Tout courrier relatif à cette affaire, doit obligatoirement être adressé sous
    </div>
    <div data-spec="motifs">
     Considérant l'objectif de respect des normes de qualité environnementale dans le milieu en 2015 fixé par la
-    <a data-date="2000" data-num="60" data-spec="document_reference" data-type="eu-directive">
+    <a data-date="2000" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb" data-num="60" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb">
      directive européenne 2000/60/CE
     </a>
     ;
@@ -6672,11 +6672,11 @@ VU pour être annexé à mon arrêté en date de 1er jour. 2010
      </div>
      <div data-number="6" data-spec="alinea">
       ☐ Autres substances pertinentes issues de la liste I de la
-      <a data-date="2006" data-num="11" data-spec="document_reference" data-type="eu-directive">
+      <a data-date="2006" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374" data-num="11" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374">
        directive 2006/11/CE
       </a>
       (anciennement
-      <a data-date="1976" data-num="464" data-spec="document_reference" data-type="eu-directive">
+      <a data-date="1976" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:2efc093a-eba8-4834-8ae6-c91d6c47db78" data-num="464" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:2efc093a-eba8-4834-8ae6-c91d6c47db78">
        Directive 76/464/CEE
       </a>
       ) et ne figurant pas à l'
@@ -6698,7 +6698,7 @@ VU pour être annexé à mon arrêté en date de 1er jour. 2010
      </div>
      <div data-number="7" data-spec="alinea">
       ☐ Autres substances pertinentes issues de la liste II de la
-      <a data-date="2006" data-num="11" data-spec="document_reference" data-type="eu-directive">
+      <a data-date="2006" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374" data-num="11" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374">
        directive 2006/11/CE
       </a>
       (anciennement
@@ -6734,7 +6734,7 @@ VU pour être annexé à mon arrêté en date de 1er jour. 2010
         annexe X
        </a>
        de la DCE (
-       <a data-date="2000" data-num="60" data-spec="document_reference" data-type="eu-directive">
+       <a data-date="2000" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb" data-num="60" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb">
         Directive 2000/60/CE
        </a>
        ).

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005302394/2012-04-03.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005302394/2012-04-03.html
@@ -435,18 +435,22 @@ RÉPUBLIQUE FRANÇAISE
      Article 1 – Liste des installations classées
     </h2>
     <div data-number="1" data-spec="alinea">
-     Le tableau de l'
-     <a data-parent_reference="4" data-spec="section_reference" data-start_num="1.2.1" data-tag_id="12" data-type="article">
+     Le
+     <a data-parent_reference="4" data-spec="section_reference" data-tag_id="13" data-type="tableau">
+      tableau
+     </a>
+     de l'
+     <a data-parent_reference="5" data-spec="section_reference" data-start_num="1.2.1" data-tag_id="4" data-type="article">
       article 1.2.1
      </a>
      de l'
-     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="4" data-type="arrete-prefectoral">
+     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="5" data-type="arrete-prefectoral">
       arrêté préfectoral d'autorisation du
       <time data-spec="date" datetime="2008-12-10">
        10 décembre 2008
       </time>
      </a>
-     <span data-direction="rtl" data-has_operand="true" data-keyword="mis à jour" data-operand="13" data-operation_type="replace" data-references="12" data-spec="operation">
+     <span data-direction="rtl" data-has_operand="true" data-keyword="mis à jour" data-operand="14" data-operation_type="replace" data-references="13" data-spec="operation">
       , relatif à l'autorisation accordée à la Société MERMIER LEMARCHAND, concernant l'exploitation d'une installation de traitement de surface et de peinture par cataphorèse sur le site situé rue de Vire à TINCHEBRAY (61800), est
       <b>
        mis à jour
@@ -455,7 +459,7 @@ RÉPUBLIQUE FRANÇAISE
      </span>
     </div>
     <div data-number="2" data-spec="alinea">
-     <table data-tag_id="13">
+     <table data-tag_id="14">
       <tr>
        <th>
         Rubrique
@@ -691,26 +695,26 @@ RÉPUBLIQUE FRANÇAISE
     </h2>
     <div data-number="1" data-spec="alinea">
      L'
-     <a data-date="2009-12-18" data-spec="document_reference" data-tag_id="14" data-type="arrete-prefectoral">
+     <a data-date="2009-12-18" data-spec="document_reference" data-tag_id="15" data-type="arrete-prefectoral">
       arrêté préfectoral complémentaire du
       <time data-spec="date" datetime="2009-12-18">
        18 décembre 2009
       </time>
      </a>
-     <span data-direction="rtl" data-keyword="abrogé" data-operation_type="delete" data-references="14" data-spec="operation">
+     <span data-direction="rtl" data-keyword="abrogé" data-operation_type="delete" data-references="15" data-spec="operation">
       est
       <b>
        abrogé
       </b>
      </span>
      . Les dispositions de l'
-     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="15" data-type="arrete-prefectoral">
+     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="16" data-type="arrete-prefectoral">
       arrêté préfectoral du
       <time data-spec="date" datetime="2008-12-10">
        10 décembre 2008
       </time>
      </a>
-     <span data-direction="rtl" data-has_operand="true" data-keyword="modifiées" data-operation_type="replace" data-references="15" data-spec="operation">
+     <span data-direction="rtl" data-has_operand="true" data-keyword="modifiées" data-operation_type="replace" data-references="16" data-spec="operation">
       susvisé sont
       <b>
        modifiées
@@ -722,15 +726,15 @@ RÉPUBLIQUE FRANÇAISE
      <ul>
       <li>
        - L’échéance de réalisation du zonage des dangers internes à l’établissement, selon les dispositions des
-       <a data-group_id="1" data-parent_reference="5" data-spec="section_reference" data-start_num="7.2.2" data-type="article">
+       <a data-group_id="1" data-parent_reference="6" data-spec="section_reference" data-start_num="7.2.2" data-type="article">
         articles 7.2.2
        </a>
        et
-       <a data-group_id="1" data-parent_reference="5" data-spec="section_reference" data-start_num="7.3.4" data-type="article">
+       <a data-group_id="1" data-parent_reference="6" data-spec="section_reference" data-start_num="7.3.4" data-type="article">
         7.3.4
        </a>
        de l’
-       <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="5" data-type="arrete">
+       <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="6" data-type="arrete">
         arrêté du
         <time data-spec="date" datetime="2008-12-10">
          10 décembre 2008
@@ -754,11 +758,11 @@ RÉPUBLIQUE FRANÇAISE
       </li>
       <li>
        - L’échéance de démantèlement des deux citernes de stockage de fioul domestique, selon l’
-       <a data-parent_reference="6" data-spec="section_reference" data-start_num="8.5.1.1" data-type="article">
+       <a data-parent_reference="7" data-spec="section_reference" data-start_num="8.5.1.1" data-type="article">
         article 8.5.1.1
        </a>
        de l’
-       <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="6" data-type="arrete">
+       <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="7" data-type="arrete">
         arrêté du
         <time data-spec="date" datetime="2008-12-10">
          10 décembre 2008
@@ -768,11 +772,11 @@ RÉPUBLIQUE FRANÇAISE
       </li>
       <li>
        - L’échéance de mise en place des portes coupe-feu entre le magasin 1000 et le magasin 2000, ainsi qu’entre le magasin 2000 et le bâtiment 65, selon l’
-       <a data-parent_reference="7" data-spec="section_reference" data-start_num="8.5.2" data-type="article">
+       <a data-parent_reference="8" data-spec="section_reference" data-start_num="8.5.2" data-type="article">
         article 8.5.2
        </a>
        de l’
-       <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="7" data-type="arrete">
+       <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="8" data-type="arrete">
         arrêté du
         <time data-spec="date" datetime="2008-12-10">
          10 décembre 2008
@@ -789,17 +793,17 @@ RÉPUBLIQUE FRANÇAISE
     </h2>
     <div data-number="1" data-spec="alinea">
      Les dispositions de l’
-     <a data-parent_reference="8" data-spec="section_reference" data-start_num="4.3.12" data-tag_id="16" data-type="article">
+     <a data-parent_reference="9" data-spec="section_reference" data-start_num="4.3.12" data-tag_id="17" data-type="article">
       article 4.3.12
      </a>
      de l’
-     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="8" data-type="arrete-prefectoral">
+     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="9" data-type="arrete-prefectoral">
       arrêté préfectoral du
       <time data-spec="date" datetime="2008-12-10">
        10 décembre 2008
       </time>
      </a>
-     <span data-direction="rtl" data-has_operand="true" data-keyword="remplacées" data-operation_type="replace" data-references="16" data-spec="operation">
+     <span data-direction="rtl" data-has_operand="true" data-keyword="remplacées" data-operation_type="replace" data-references="17" data-spec="operation">
       susvisé sont
       <b>
        remplacées
@@ -866,17 +870,17 @@ RÉPUBLIQUE FRANÇAISE
     </h2>
     <div data-number="1" data-spec="alinea">
      Les dispositions de l’
-     <a data-parent_reference="9" data-spec="section_reference" data-start_num="7.3.5" data-tag_id="17" data-type="article">
+     <a data-parent_reference="10" data-spec="section_reference" data-start_num="7.3.5" data-tag_id="18" data-type="article">
       article 7.3.5
      </a>
      de l’
-     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="9" data-type="arrete-prefectoral">
+     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="10" data-type="arrete-prefectoral">
       arrêté préfectoral du
       <time data-spec="date" datetime="2008-12-10">
        10 décembre 2008
       </time>
      </a>
-     <span data-direction="rtl" data-has_operand="true" data-keyword="remplacées" data-operand="18" data-operation_type="replace" data-references="17" data-spec="operation">
+     <span data-direction="rtl" data-has_operand="true" data-keyword="remplacées" data-operand="19" data-operation_type="replace" data-references="18" data-spec="operation">
       susvisé sont
       <b>
        remplacées
@@ -885,14 +889,14 @@ RÉPUBLIQUE FRANÇAISE
      </span>
     </div>
     <div data-number="2" data-spec="alinea">
-     <blockquote data-tag_id="18">
+     <blockquote data-tag_id="19">
       <p>
        Les installations sur lesquelles une agression par la foudre peut être à l’origine d’événements susceptibles de porter gravement atteinte, directement ou indirectement à la sécurité des installations, à la sécurité des personnes ou à la qualité de l’environnement, sont protégées contre la foudre en application des
-       <a data-end_num="23" data-parent_reference="10" data-spec="section_reference" data-start_num="16" data-type="article">
+       <a data-end_num="23" data-parent_reference="11" data-spec="section_reference" data-start_num="16" data-type="article">
         articles 16 à 23
        </a>
        de l’
-       <a data-date="2010-10-04" data-id="JORFTEXT000023081900" data-spec="document_reference" data-tag_id="10" data-type="arrete-ministeriel" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000023081900">
+       <a data-date="2010-10-04" data-id="JORFTEXT000023081900" data-spec="document_reference" data-tag_id="11" data-type="arrete-ministeriel" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000023081900">
         arrêté ministériel du
         <time data-spec="date" datetime="2010-10-04">
          04 octobre 2010
@@ -925,11 +929,11 @@ RÉPUBLIQUE FRANÇAISE
       </li>
       <li>
        2° Par les tiers, personnes physiques ou morales, les communes intéressées ou leurs groupements, en raison des inconvénients ou des dangers que le fonctionnement de l'installation présente pour les intérêts visés à l'
-       <a data-parent_reference="11" data-spec="section_reference" data-start_id="LEGIARTI000043978078" data-start_num="L511-1" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043978078">
+       <a data-parent_reference="12" data-spec="section_reference" data-start_id="LEGIARTI000043978078" data-start_num="L511-1" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043978078">
         article L. 511-1
        </a>
        du
-       <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="11" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+       <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="12" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
         code de l'environnement
        </a>
        , dans un délai d'un an à compter de la publication ou de l'affichage de l'arrêté.

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005302394/2012-12-07.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005302394/2012-12-07.html
@@ -298,7 +298,7 @@ RÉPUBLIQUE FRANÇAISE
    </div>
    <div data-spec="visa">
     Vu la
-    <a data-date="2006" data-num="11" data-spec="document_reference" data-type="eu-directive">
+    <a data-date="2006" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374" data-num="11" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374">
      directive 2006/11/CE
     </a>
     concernant la pollution causée par certaines substances dangereuses déversées dans le milieu aquatique de la Communauté ;

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005302394/2012-12-07.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005302394/2012-12-07.html
@@ -298,14 +298,14 @@ RÉPUBLIQUE FRANÇAISE
    </div>
    <div data-spec="visa">
     Vu la
-    <a data-date="2006" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374" data-num="11" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374">
+    <a data-date="2006" data-num="11" data-spec="document_reference" data-type="eu-directive">
      directive 2006/11/CE
     </a>
     concernant la pollution causée par certaines substances dangereuses déversées dans le milieu aquatique de la Communauté ;
    </div>
    <div data-spec="visa">
     Vu la
-    <a data-date="2000" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb" data-num="60" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb">
+    <a data-date="2000" data-num="60" data-spec="document_reference" data-type="eu-directive">
      directive 2000/60/CE
     </a>
     du 23 octobre 2000 établissant un cadre pour une politique communautaire dans le domaine de l'eau (DCE) ;
@@ -503,7 +503,7 @@ RÉPUBLIQUE FRANÇAISE
    </div>
    <div data-spec="motifs">
     Considérant l'objectif de respect des normes de qualité environnementale dans le milieu en 2015 fixé par la
-    <a data-date="2000" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb" data-num="60" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb">
+    <a data-date="2000" data-num="60" data-spec="document_reference" data-type="eu-directive">
      directive 2000/60/CE
     </a>
     ;

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005302394/2012-12-07.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005302394/2012-12-07.html
@@ -305,7 +305,7 @@ RÉPUBLIQUE FRANÇAISE
    </div>
    <div data-spec="visa">
     Vu la
-    <a data-date="2000" data-num="60" data-spec="document_reference" data-type="eu-directive">
+    <a data-date="2000" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb" data-num="60" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb">
      directive 2000/60/CE
     </a>
     du 23 octobre 2000 établissant un cadre pour une politique communautaire dans le domaine de l'eau (DCE) ;
@@ -503,7 +503,7 @@ RÉPUBLIQUE FRANÇAISE
    </div>
    <div data-spec="motifs">
     Considérant l'objectif de respect des normes de qualité environnementale dans le milieu en 2015 fixé par la
-    <a data-date="2000" data-num="60" data-spec="document_reference" data-type="eu-directive">
+    <a data-date="2000" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb" data-num="60" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb">
      directive 2000/60/CE
     </a>
     ;

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005302394/2020-12-22.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005302394/2020-12-22.html
@@ -310,7 +310,7 @@ Section environnement
    </div>
    <div data-spec="visa">
     Vu la
-    <a data-date="2010" data-num="75" data-spec="document_reference" data-type="eu-directive">
+    <a data-date="2010" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082" data-num="75" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082">
      directive 2010/75/UE
     </a>
     relative aux émissions industrielles, dite " IED " ;

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005302394/2020-12-22.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005302394/2020-12-22.html
@@ -310,7 +310,7 @@ Section environnement
    </div>
    <div data-spec="visa">
     Vu la
-    <a data-date="2010" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082" data-num="75" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:c7191b72-4e07-4712-86d6-d3ae5e4f0082">
+    <a data-date="2010" data-num="75" data-spec="document_reference" data-type="eu-directive">
      directive 2010/75/UE
     </a>
     relative aux émissions industrielles, dite " IED " ;
@@ -354,7 +354,11 @@ Section environnement
       3 avril 2012
      </time>
     </a>
-    relatif à la mise à jour du tableau de classement du site et de certaines échéances prévues dans l'
+    relatif à la mise à jour du
+    <a data-spec="section_reference" data-type="tableau">
+     tableau
+    </a>
+    de classement du site et de certaines échéances prévues dans l'
     <a data-date="2008-12-10" data-spec="document_reference" data-type="arrete">
      arrêté du
      <time data-spec="date" datetime="2008-12-10">
@@ -383,7 +387,11 @@ Section environnement
     Vu les courriers de la société Mermier-Lemarchand en date du 31 juillet et du 29 septembre 2020 répondant aux suites de l'inspection du 2 juillet 2020 ;
    </div>
    <div data-spec="motifs">
-    Considérant que tableau de classement du site au regard de la nomenclature des installations classées doit être mis à jour, notamment vis-à-vis du classement IED du site ;
+    Considérant que
+    <a data-spec="section_reference" data-type="tableau">
+     tableau
+    </a>
+    de classement du site au regard de la nomenclature des installations classées doit être mis à jour, notamment vis-à-vis du classement IED du site ;
    </div>
    <div data-spec="motifs">
     Considérant que des travaux ont été réalisés sur le site, permettant de supprimer certaines dispositions de l'
@@ -487,8 +495,12 @@ Section environnement
   </header>
   <main data-spec="main">
    <div data-number="1" data-spec="alinea">
-    Le tableau de classement du site, précisé à l'
-    <a data-parent_reference="5" data-spec="section_reference" data-start_num="1.2.1" data-tag_id="28" data-type="article">
+    Le
+    <a data-spec="section_reference" data-type="tableau">
+     tableau
+    </a>
+    de classement du site, précisé à l'
+    <a data-parent_reference="5" data-spec="section_reference" data-start_num="1.2.1" data-tag_id="29" data-type="article">
      article 1.2.1
     </a>
     de l'
@@ -498,13 +510,17 @@ Section environnement
       10 décembre 2008
      </time>
     </a>
-    <span data-direction="rtl" data-has_operand="true" data-keyword="remplacé" data-operation_type="replace" data-references="28" data-spec="operation">
+    <span data-direction="rtl" data-keyword="remplacé" data-operation_type="replace" data-references="29" data-spec="operation">
      est
      <b>
       remplacé
      </b>
-     par le tableau suivant :
+     par le
     </span>
+    <a data-spec="section_reference" data-type="tableau">
+     tableau
+    </a>
+    suivant :
    </div>
    <section data-number="1" data-spec="section" data-type="article">
     <h2 data-level="0" data-spec="section_title">
@@ -736,7 +752,7 @@ Section environnement
     </h2>
     <div data-number="1" data-spec="alinea">
      L'
-     <a data-parent_reference="6" data-spec="section_reference" data-start_num="3.2.1" data-tag_id="29" data-type="article">
+     <a data-parent_reference="6" data-spec="section_reference" data-start_num="3.2.1" data-tag_id="30" data-type="article">
       article 3.2.1
      </a>
      de l'
@@ -746,7 +762,7 @@ Section environnement
        10 décembre 2008
       </time>
      </a>
-     <span data-direction="rtl" data-has_operand="true" data-keyword="modifié" data-operation_type="replace" data-references="29" data-spec="operation">
+     <span data-direction="rtl" data-has_operand="true" data-keyword="modifié" data-operation_type="replace" data-references="30" data-spec="operation">
       est
       <b>
        modifié
@@ -776,27 +792,35 @@ Section environnement
      ARTICLE 3
     </h2>
     <div data-number="1" data-spec="alinea">
-     Le tableau de l'
-     <a data-parent_reference="7" data-spec="section_reference" data-start_num="4.3.9" data-tag_id="30" data-type="article">
+     Le
+     <a data-parent_reference="7" data-spec="section_reference" data-tag_id="31" data-type="tableau">
+      tableau
+     </a>
+     de l'
+     <a data-parent_reference="8" data-spec="section_reference" data-start_num="4.3.9" data-tag_id="7" data-type="article">
       article 4.3.9
      </a>
      de l'
-     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="7" data-type="arrete">
+     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="8" data-type="arrete">
       arrêté du
       <time data-spec="date" datetime="2008-12-10">
        10 décembre 2008
       </time>
      </a>
-     <span data-direction="rtl" data-has_operand="true" data-keyword="remplacé" data-operand="31" data-operation_type="replace" data-references="30" data-spec="operation">
+     <span data-direction="rtl" data-keyword="remplacé" data-operation_type="replace" data-references="31" data-spec="operation">
       est
       <b>
        remplacé
       </b>
-      par le tableau suivant :
+      par le
      </span>
+     <a data-spec="section_reference" data-type="tableau">
+      tableau
+     </a>
+     suivant :
     </div>
     <div data-number="2" data-spec="alinea">
-     <table data-tag_id="31">
+     <table>
       <tr>
        <th>
         Paramètre
@@ -949,11 +973,11 @@ Section environnement
     </h2>
     <div data-number="1" data-spec="alinea">
      Les dispositions de l'
-     <a data-parent_reference="8" data-spec="section_reference" data-start_num="4.3.12" data-tag_id="32" data-type="article">
+     <a data-parent_reference="9" data-spec="section_reference" data-start_num="4.3.12" data-tag_id="32" data-type="article">
       article 4.3.12
      </a>
      de l'
-     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="8" data-type="arrete">
+     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="9" data-type="arrete">
       arrêté du
       <time data-spec="date" datetime="2008-12-10">
        10 décembre 2008
@@ -1028,11 +1052,11 @@ Section environnement
     </h2>
     <div data-number="1" data-spec="alinea">
      Les dispositions de l'
-     <a data-parent_reference="9" data-spec="section_reference" data-start_num="4.3.13" data-tag_id="34" data-type="article">
+     <a data-parent_reference="10" data-spec="section_reference" data-start_num="4.3.13" data-tag_id="34" data-type="article">
       article 4.3.13
      </a>
      de l'
-     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="9" data-type="arrete">
+     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="10" data-type="arrete">
       arrêté du
       <time data-spec="date" datetime="2008-12-10">
        10 décembre 2008
@@ -1136,11 +1160,11 @@ Section environnement
     </h2>
     <div data-number="1" data-spec="alinea">
      La dernière phrase de l'
-     <a data-parent_reference="10" data-spec="section_reference" data-start_num="7.2.2" data-tag_id="36" data-type="article">
+     <a data-parent_reference="11" data-spec="section_reference" data-start_num="7.2.2" data-tag_id="36" data-type="article">
       article 7.2.2
      </a>
      de l'
-     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="10" data-type="arrete-prefectoral">
+     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="11" data-type="arrete-prefectoral">
       arrêté préfectoral du
       <time data-spec="date" datetime="2008-12-10">
        10 décembre 2008
@@ -1161,11 +1185,11 @@ Section environnement
     </h2>
     <div data-number="1" data-spec="alinea">
      Les dispositions de l'
-     <a data-parent_reference="11" data-spec="section_reference" data-start_num="7.3.5" data-tag_id="37" data-type="article">
+     <a data-parent_reference="12" data-spec="section_reference" data-start_num="7.3.5" data-tag_id="37" data-type="article">
       article 7.3.5
      </a>
      de l'
-     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="11" data-type="arrete-prefectoral">
+     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="12" data-type="arrete-prefectoral">
       arrêté préfectoral du
       <time data-spec="date" datetime="2008-12-10">
        10 décembre 2008
@@ -1183,11 +1207,11 @@ Section environnement
      <blockquote data-tag_id="38">
       <p>
        Les installations sur lesquelles une agression par la foudre peut être à l'origine d'événements susceptibles de porter gravement atteinte, directement ou indirectement à la sécurité des installations, à la sécurité des personnes ou à la qualité de l'environnement, sont protégées contre la foudre en application des
-       <a data-end_num="23" data-parent_reference="12" data-spec="section_reference" data-start_num="16" data-type="article">
+       <a data-end_num="23" data-parent_reference="13" data-spec="section_reference" data-start_num="16" data-type="article">
         articles 16 à 23
        </a>
        de l'
-       <a data-date="2010-10-04" data-id="JORFTEXT000023081900" data-spec="document_reference" data-tag_id="12" data-type="arrete-ministeriel" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000023081900">
+       <a data-date="2010-10-04" data-id="JORFTEXT000023081900" data-spec="document_reference" data-tag_id="13" data-type="arrete-ministeriel" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000023081900">
         arrêté ministériel du
         <time data-spec="date" datetime="2010-10-04">
          04 octobre 2010
@@ -1197,11 +1221,11 @@ Section environnement
       </p>
       <p>
        Une analyse du risque foudre (ARF) réalisée conformément aux dispositions de l'
-       <a data-parent_reference="13" data-spec="section_reference" data-start_num="18" data-type="article">
+       <a data-parent_reference="14" data-spec="section_reference" data-start_num="18" data-type="article">
         article 18
        </a>
        de l'
-       <a data-date="2010-10-04" data-spec="document_reference" data-tag_id="13" data-type="arrete-ministeriel">
+       <a data-date="2010-10-04" data-spec="document_reference" data-tag_id="14" data-type="arrete-ministeriel">
         arrêté ministériel du
         <time data-spec="date" datetime="2010-10-04">
          04 octobre 2010
@@ -1218,11 +1242,11 @@ Section environnement
     </h2>
     <div data-number="1" data-spec="alinea">
      Les dispositions de l'
-     <a data-parent_reference="14" data-spec="section_reference" data-start_num="7.6.2" data-tag_id="39" data-type="article">
+     <a data-parent_reference="15" data-spec="section_reference" data-start_num="7.6.2" data-tag_id="39" data-type="article">
       article 7.6.2
      </a>
      de l'
-     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="14" data-type="arrete-prefectoral">
+     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="15" data-type="arrete-prefectoral">
       arrêté préfectoral du
       <time data-spec="date" datetime="2008-12-10">
        10 décembre 2008
@@ -1275,11 +1299,11 @@ Section environnement
     </h2>
     <div data-number="1" data-spec="alinea">
      La dernière phrase de l'
-     <a data-parent_reference="15" data-spec="section_reference" data-start_num="7.6.8.1" data-tag_id="40" data-type="article">
+     <a data-parent_reference="16" data-spec="section_reference" data-start_num="7.6.8.1" data-tag_id="40" data-type="article">
       article 7.6.8.1
      </a>
      de l'
-     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="15" data-type="arrete-prefectoral">
+     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="16" data-type="arrete-prefectoral">
       arrêté préfectoral du
       <time data-spec="date" datetime="2008-12-10">
        10 décembre 2008
@@ -1307,11 +1331,11 @@ Section environnement
     </h2>
     <div data-number="1" data-spec="alinea">
      Les dispositions de l'
-     <a data-parent_reference="16" data-spec="section_reference" data-start_num="7.6.8.2" data-tag_id="42" data-type="article">
+     <a data-parent_reference="17" data-spec="section_reference" data-start_num="7.6.8.2" data-tag_id="42" data-type="article">
       article 7.6.8.2
      </a>
      de l'
-     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="16" data-type="arrete-prefectoral">
+     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="17" data-type="arrete-prefectoral">
       arrêté préfectoral du
       <time data-spec="date" datetime="2008-12-10">
        10 décembre 2008
@@ -1382,11 +1406,11 @@ Section environnement
     </h2>
     <div data-number="1" data-spec="alinea">
      Les dispositions de l'
-     <a data-parent_reference="17" data-spec="section_reference" data-start_num="8.1.1.1" data-tag_id="44" data-type="article">
+     <a data-parent_reference="18" data-spec="section_reference" data-start_num="8.1.1.1" data-tag_id="44" data-type="article">
       article 8.1.1.1
      </a>
      de l'
-     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="17" data-type="arrete-prefectoral">
+     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="18" data-type="arrete-prefectoral">
       arrêté préfectoral du
       <time data-spec="date" datetime="2008-12-10">
        10 décembre 2008
@@ -1414,11 +1438,11 @@ Section environnement
     </h2>
     <div data-number="1" data-spec="alinea">
      La dernière phrase de l'
-     <a data-parent_reference="18" data-spec="section_reference" data-start_num="8.1.1.2" data-tag_id="46" data-type="article">
+     <a data-parent_reference="19" data-spec="section_reference" data-start_num="8.1.1.2" data-tag_id="46" data-type="article">
       article 8.1.1.2
      </a>
      de l'
-     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="18" data-type="arrete-prefectoral">
+     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="19" data-type="arrete-prefectoral">
       arrêté préfectoral du
       <time data-spec="date" datetime="2008-12-10">
        10 décembre 2008
@@ -1443,11 +1467,11 @@ Section environnement
     </h2>
     <div data-number="1" data-spec="alinea">
      La dernière phrase de l'
-     <a data-parent_reference="19" data-spec="section_reference" data-start_num="8.1.1.3" data-tag_id="48" data-type="article">
+     <a data-parent_reference="20" data-spec="section_reference" data-start_num="8.1.1.3" data-tag_id="48" data-type="article">
       article 8.1.1.3
      </a>
      de l'
-     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="19" data-type="arrete-prefectoral">
+     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="20" data-type="arrete-prefectoral">
       arrêté préfectoral du
       <time data-spec="date" datetime="2008-12-10">
        10 décembre 2008
@@ -1472,19 +1496,19 @@ Section environnement
     </h2>
     <div data-number="1" data-spec="alinea">
      Les
-     <a data-group_id="2" data-parent_reference="20" data-spec="section_reference" data-start_num="3" data-tag_id="50" data-type="alinea">
+     <a data-group_id="2" data-parent_reference="21" data-spec="section_reference" data-start_num="3" data-tag_id="50" data-type="alinea">
       paragraphes 3
      </a>
      et
-     <a data-group_id="2" data-parent_reference="20" data-spec="section_reference" data-start_num="4" data-tag_id="51" data-type="alinea">
+     <a data-group_id="2" data-parent_reference="21" data-spec="section_reference" data-start_num="4" data-tag_id="51" data-type="alinea">
       4
      </a>
      de l'
-     <a data-parent_reference="21" data-spec="section_reference" data-start_num="8.5.1.1" data-tag_id="20" data-type="article">
+     <a data-parent_reference="22" data-spec="section_reference" data-start_num="8.5.1.1" data-tag_id="21" data-type="article">
       article 8.5.1.1
      </a>
      de l'
-     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="21" data-type="arrete-prefectoral">
+     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="22" data-type="arrete-prefectoral">
       arrêté préfectoral du
       <time data-spec="date" datetime="2008-12-10">
        10 décembre 2008
@@ -1504,11 +1528,11 @@ Section environnement
     </h2>
     <div data-number="1" data-spec="alinea">
      Les dispositions de l'
-     <a data-parent_reference="22" data-spec="section_reference" data-start_num="8.5.2" data-tag_id="52" data-type="article">
+     <a data-parent_reference="23" data-spec="section_reference" data-start_num="8.5.2" data-tag_id="52" data-type="article">
       article 8.5.2
      </a>
      de l'
-     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="22" data-type="arrete-prefectoral">
+     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="23" data-type="arrete-prefectoral">
       arrêté préfectoral du
       <time data-spec="date" datetime="2008-12-10">
        10 décembre 2008
@@ -1552,11 +1576,11 @@ Section environnement
     </h2>
     <div data-number="1" data-spec="alinea">
      L'
-     <a data-parent_reference="23" data-spec="section_reference" data-start_num="8.5.3" data-tag_id="54" data-type="article">
+     <a data-parent_reference="24" data-spec="section_reference" data-start_num="8.5.3" data-tag_id="54" data-type="article">
       article 8.5.3
      </a>
      de l'
-     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="23" data-type="arrete-prefectoral">
+     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="24" data-type="arrete-prefectoral">
       arrêté préfectoral du
       <time data-spec="date" datetime="2008-12-10">
        10 décembre 2008
@@ -1577,11 +1601,11 @@ Section environnement
     </h2>
     <div data-number="1" data-spec="alinea">
      L'
-     <a data-parent_reference="24" data-spec="section_reference" data-start_num="9.2.3.1" data-tag_id="55" data-type="article">
+     <a data-parent_reference="25" data-spec="section_reference" data-start_num="9.2.3.1" data-tag_id="55" data-type="article">
       article 9.2.3.1
      </a>
      de l'
-     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="24" data-type="arrete-prefectoral">
+     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="25" data-type="arrete-prefectoral">
       arrêté préfectoral du
       <time data-spec="date" datetime="2008-12-10">
        10 décembre 2008
@@ -1596,11 +1620,25 @@ Section environnement
      </span>
     </div>
     <div data-number="2" data-spec="alinea">
-     Le tableau présenté dans la section
+     Le
+     <a data-spec="section_reference" data-type="tableau">
+      tableau
+     </a>
+     présenté dans la section
      <q>
       eaux résiduaires après détoxication
      </q>
-     est remplacé par le tableau suivant :
+     <span data-direction="rtl" data-keyword="remplacé" data-operation_type="replace" data-spec="operation">
+      est
+      <b>
+       remplacé
+      </b>
+      par le
+     </span>
+     <a data-spec="section_reference" data-type="tableau">
+      tableau
+     </a>
+     suivant :
     </div>
     <div data-number="3" data-spec="alinea">
      <table>
@@ -1674,11 +1712,11 @@ Section environnement
      <blockquote>
       <p>
        Si les résultats d'analyses au terme de 6 mois de surveillance indiquent que l'indice hydrocarbure n'est présent qu'à l'état de traces dans les rejets, sa surveillance repassera à une fréquence trimestrielle uniquement. Toutefois, si 2 analyses trimestrielles consécutives montrent des analyses dont les résultats sont au-dessus des valeurs prévues à l'
-       <a data-parent_reference="25" data-spec="section_reference" data-start_num="4.3.9" data-type="article">
+       <a data-parent_reference="26" data-spec="section_reference" data-start_num="4.3.9" data-type="article">
         article 4.3.9
        </a>
        de l'
-       <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="25" data-type="arrete">
+       <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="26" data-type="arrete">
         arrêté du
         <time data-spec="date" datetime="2008-12-10">
          10 décembre 2008
@@ -1699,15 +1737,15 @@ Section environnement
       (messagerie électronique)
      </q>
      précisée au
-     <a data-parent_reference="26" data-spec="section_reference" data-start_num="4" data-tag_id="56" data-type="alinea">
+     <a data-parent_reference="27" data-spec="section_reference" data-start_num="4" data-tag_id="56" data-type="alinea">
       4ᵉ paragraphe
      </a>
      de l'
-     <a data-parent_reference="27" data-spec="section_reference" data-start_num="9.2.3.2" data-tag_id="26" data-type="article">
+     <a data-parent_reference="28" data-spec="section_reference" data-start_num="9.2.3.2" data-tag_id="27" data-type="article">
       article 9.2.3.2
      </a>
      de l'
-     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="27" data-type="arrete-prefectoral">
+     <a data-date="2008-12-10" data-spec="document_reference" data-tag_id="28" data-type="arrete-prefectoral">
       arrêté préfectoral du
       <time data-spec="date" datetime="2008-12-10">
        10 décembre 2008

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005800425/2003-09-09.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005800425/2003-09-09.html
@@ -2114,7 +2114,11 @@ Page 14/23
        3.4.6. Émergences admissibles
       </h4>
       <div data-number="1" data-spec="alinea">
-       Les émissions sonores de l’installation ne doivent pas engendrer une émergence supérieure aux valeurs admissibles fixées dans le tableau ci-après, dans les zones d’émergence réglementées telles que définies dans l’
+       Les émissions sonores de l’installation ne doivent pas engendrer une émergence supérieure aux valeurs admissibles fixées dans le
+       <a data-spec="section_reference" data-type="tableau">
+        tableau
+       </a>
+       ci-après, dans les zones d’émergence réglementées telles que définies dans l’
        <a data-date="1997-01-23" data-spec="document_reference" data-type="arrete-ministeriel">
         arrêté ministériel du
         <time data-spec="date" datetime="1997-01-23">
@@ -2249,23 +2253,27 @@ Page 15/23
       Il veille à tout moment à son application et met en place des dispositions pour le contrôle de cette application.
      </div>
      <div data-number="6" data-spec="alinea">
-      L'exploitant procède au recensement régulier des substances ou préparations dangereuses susceptibles d'être présentes dans l'établissement (nature, état physique et quantité) et relevant d'une rubrique figurant en colonne de gauche du tableau de l'
-      <a data-parent_reference="17" data-spec="section_reference" data-start_num="1" data-type="annexe">
+      L'exploitant procède au recensement régulier des substances ou préparations dangereuses susceptibles d'être présentes dans l'établissement (nature, état physique et quantité) et relevant d'une rubrique figurant en colonne de gauche du
+      <a data-parent_reference="17" data-spec="section_reference" data-type="tableau">
+       tableau
+      </a>
+      de l'
+      <a data-parent_reference="18" data-spec="section_reference" data-start_num="1" data-tag_id="17" data-type="annexe">
        annexe I
       </a>
       de l'
-      <a data-date="2000-05-10" data-spec="document_reference" data-tag_id="17" data-type="arrete">
+      <a data-date="2000-05-10" data-spec="document_reference" data-tag_id="18" data-type="arrete">
        arrêté du
        <time data-spec="date" datetime="2000-05-10">
         10 mai 2000
        </time>
       </a>
       relatif à la prévention des accidents majeurs impliquant des substances ou des préparations dangereuses présentes dans certaines catégories d'installations classées pour la protection de l'environnement soumises à autorisation ou d'une rubrique visant une installation de l'établissement figurant sur la liste prévue à l'
-      <a data-parent_reference="18" data-spec="section_reference" data-start_id="LEGIARTI000027722889" data-start_num="L515-8" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000027722889">
+      <a data-parent_reference="19" data-spec="section_reference" data-start_id="LEGIARTI000027722889" data-start_num="L515-8" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000027722889">
        article L 515-8
       </a>
       du
-      <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="18" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+      <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="19" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
        code de l'environnement
       </a>
       .
@@ -2578,11 +2586,11 @@ Page 17/23
       </div>
       <div data-number="4" data-spec="alinea">
        L'exploitant doit avoir à sa disposition des documents lui permettant de connaître la nature et les risques des produits mis en œuvre (notamment le TDI, le MDI, le dichlorométhane et le CO₂), en particulier les fiches de données de sécurité prévues par l'
-       <a data-parent_reference="19" data-spec="section_reference" data-start_id="LEGIARTI000018513110" data-start_num="R231-53" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000018513110">
+       <a data-parent_reference="20" data-spec="section_reference" data-start_id="LEGIARTI000018513110" data-start_num="R231-53" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000018513110">
         article R. 231-53
        </a>
        du
-       <a data-id="LEGITEXT000006072050" data-spec="document_reference" data-tag_id="19" data-title="Code du travail" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072050">
+       <a data-id="LEGITEXT000006072050" data-spec="document_reference" data-tag_id="20" data-title="Code du travail" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072050">
         Code du travail
        </a>
        .
@@ -3070,11 +3078,11 @@ Page 23/23
      </div>
      <div data-number="5" data-spec="alinea">
       L'exploitant doit remettre le site de l'installation dans un état tel qu'il ne s'y manifeste aucun des dangers ou inconvénients mentionnés à l'
-      <a data-parent_reference="20" data-spec="section_reference" data-start_id="LEGIARTI000043978078" data-start_num="L511-1" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043978078">
+      <a data-parent_reference="21" data-spec="section_reference" data-start_id="LEGIARTI000043978078" data-start_num="L511-1" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043978078">
        article L 511-1
       </a>
       du
-      <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="20" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+      <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="21" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
        code de l'environnement
       </a>
       .

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005800425/2005-11-08.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005800425/2005-11-08.html
@@ -1880,7 +1880,11 @@ Télécopie : 02 32.38.24.15
       <a data-page_index="11" data-spec="page_separator">
       </a>
       <div data-number="1" data-spec="alinea">
-       Les émissions sonores de l'installation ne doivent pas engendrer une émergence supérieure aux valeurs admissibles fixées dans le tableau ci-après, dans les zones d'émergence réglementées telles que définies dans l'
+       Les émissions sonores de l'installation ne doivent pas engendrer une émergence supérieure aux valeurs admissibles fixées dans le
+       <a data-spec="section_reference" data-type="tableau">
+        tableau
+       </a>
+       ci-après, dans les zones d'émergence réglementées telles que définies dans l'
        <a data-date="1997-01-23" data-spec="document_reference" data-type="arrete-ministeriel">
         arrêté ministériel du
         <time data-spec="date" datetime="1997-01-23">
@@ -2007,23 +2011,27 @@ Télécopie : 02 32.38.24.15
       Il veille à tout moment à son application et met en place des dispositions pour le contrôle de cette application.
      </div>
      <div data-number="6" data-spec="alinea">
-      L'exploitant procède au recensement régulier des substances ou préparations dangereuses susceptibles d'être présentes dans l'établissement (nature, état physique et quantité) et relevant d'une rubrique figurant en colonne de gauche du tableau de l'
-      <a data-parent_reference="14" data-spec="section_reference" data-start_num="1" data-type="annexe">
+      L'exploitant procède au recensement régulier des substances ou préparations dangereuses susceptibles d'être présentes dans l'établissement (nature, état physique et quantité) et relevant d'une rubrique figurant en colonne de gauche du
+      <a data-parent_reference="14" data-spec="section_reference" data-type="tableau">
+       tableau
+      </a>
+      de l'
+      <a data-parent_reference="15" data-spec="section_reference" data-start_num="1" data-tag_id="14" data-type="annexe">
        annexe I
       </a>
       de l'
-      <a data-date="2000-05-10" data-spec="document_reference" data-tag_id="14" data-type="arrete">
+      <a data-date="2000-05-10" data-spec="document_reference" data-tag_id="15" data-type="arrete">
        arrêté du
        <time data-spec="date" datetime="2000-05-10">
         10 mai 2000
        </time>
       </a>
       relatif à la prévention des accidents majeurs impliquant des substances ou des préparations dangereuses présentes dans certaines catégories d'installations classées pour la protection de l'environnement soumises à autorisation ou d'une rubrique visant une installation de l'établissement figurant sur la liste prévue à l'
-      <a data-parent_reference="15" data-spec="section_reference" data-start_id="LEGIARTI000027722889" data-start_num="L515-8" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000027722889">
+      <a data-parent_reference="16" data-spec="section_reference" data-start_id="LEGIARTI000027722889" data-start_num="L515-8" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000027722889">
        article L 515-8
       </a>
       du
-      <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="15" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+      <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="16" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
        Code de l'Environnement
       </a>
       .
@@ -2572,11 +2580,11 @@ Télécopie : 02 32.38.24.15
       </div>
       <div data-number="4" data-spec="alinea">
        L'exploitant doit avoir à sa disposition des documents lui permettant de connaître la nature et les risques des produits mis en œuvre (notamment le TDI, le MDI et le CO₂), en particulier les fiches de données de sécurité prévues par l'
-       <a data-parent_reference="16" data-spec="section_reference" data-start_id="LEGIARTI000018513110" data-start_num="R231-53" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000018513110">
+       <a data-parent_reference="17" data-spec="section_reference" data-start_id="LEGIARTI000018513110" data-start_num="R231-53" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000018513110">
         article R. 231-53
        </a>
        du
-       <a data-id="LEGITEXT000006072050" data-spec="document_reference" data-tag_id="16" data-title="Code du travail" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072050">
+       <a data-id="LEGITEXT000006072050" data-spec="document_reference" data-tag_id="17" data-title="Code du travail" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072050">
         Code du travail
        </a>
        .
@@ -3056,11 +3064,11 @@ Télécopie : 02 32.38.24.15
      </div>
      <div data-number="8" data-spec="alinea">
       L’exploitant doit remettre le site de l’installation dans un état tel qu’il ne s’y manifeste aucun des dangers ou inconvénients mentionnés à l’
-      <a data-parent_reference="17" data-spec="section_reference" data-start_id="LEGIARTI000043978078" data-start_num="L511-1" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043978078">
+      <a data-parent_reference="18" data-spec="section_reference" data-start_id="LEGIARTI000043978078" data-start_num="L511-1" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043978078">
        article L 511-1
       </a>
       du
-      <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="17" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+      <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="18" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
        Code de l’Environnement
       </a>
       .
@@ -3073,11 +3081,11 @@ Télécopie : 02 32.38.24.15
     </h2>
     <div data-number="1" data-spec="alinea">
      Conformément à l’
-     <a data-parent_reference="18" data-spec="section_reference" data-start_id="LEGIARTI000033933152" data-start_num="L514-6" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000033933152">
+     <a data-parent_reference="19" data-spec="section_reference" data-start_id="LEGIARTI000033933152" data-start_num="L514-6" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000033933152">
       article L. 514-6
      </a>
      du
-     <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="18" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+     <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="19" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
       code de l’environnement
      </a>
      , la présente décision ne peut être déférée qu’au tribunal administratif. Le délai de recours est de deux mois pour l’exploitant et de quatre ans pour les tiers. Ce délai commence à courir du jour où la présente décision a été notifiée.

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005800425/2010-03-29.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005800425/2010-03-29.html
@@ -290,14 +290,14 @@ RÉPUBLIQUE FRANÇAISE
    </div>
    <div data-spec="visa">
     Vu la
-    <a data-date="2006" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374" data-num="11" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374">
+    <a data-date="2006" data-num="11" data-spec="document_reference" data-type="eu-directive">
      directive 2006/11/CE
     </a>
     concernant la pollution causée par certaines substances dangereuses déversées dans le milieu aquatique de la Communauté ;
    </div>
    <div data-spec="visa">
     Vu la
-    <a data-date="2000" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb" data-num="60" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb">
+    <a data-date="2000" data-num="60" data-spec="document_reference" data-type="eu-directive">
      directive 2000/60/CE
     </a>
     du 23 octobre 2000 établissant un cadre pour une politique communautaire dans le domaine de l'eau (DCE) ;
@@ -452,7 +452,7 @@ RÉPUBLIQUE FRANÇAISE
    </div>
    <div data-spec="motifs">
     Considérant l'objectif de respect des normes de qualité environnementale dans le milieu en 2015 fixé par la
-    <a data-date="2000" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb" data-num="60" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb">
+    <a data-date="2000" data-num="60" data-spec="document_reference" data-type="eu-directive">
      directive 2000/60/CE
     </a>
     ;
@@ -590,7 +590,11 @@ RÉPUBLIQUE FRANÇAISE
       2. Liste de références en matière d'opérations de prélèvements de substances dangereuses dans les rejets industriels
      </h3>
      <div data-number="1" data-spec="alinea">
-      3. Tableau des performances et d'assurance qualité précisant les limites de quantification pour l'analyse des substances qui doivent être inférieures ou égales à celles de l'
+      3.
+      <a data-spec="section_reference" data-type="tableau">
+       Tableau
+      </a>
+      des performances et d'assurance qualité précisant les limites de quantification pour l'analyse des substances qui doivent être inférieures ou égales à celles de l'
       <a data-parent_reference="5" data-spec="section_reference" data-start_num="5.2" data-type="annexe">
        annexe 5.2
       </a>
@@ -1088,7 +1092,19 @@ RÉPUBLIQUE FRANÇAISE
     <div data-number="2" data-spec="alinea">
      <ul>
       <li>
-       - Un tableau récapitulatif des mesures sous une forme synthétique. Ce tableau comprend, pour chaque substance, sa concentration et son flux, pour chacune des mesures réalisées. Le tableau comprend également les concentrations minimale, maximale et moyenne mesurées sur les six échantillons, ainsi que les flux minimal, maximal et moyen calculés à partir des six mesures et les limites de quantification pour chaque mesure;
+       - Un
+       <a data-spec="section_reference" data-type="tableau">
+        tableau
+       </a>
+       récapitulatif des mesures sous une forme synthétique. Ce
+       <a data-spec="section_reference" data-type="tableau">
+        tableau
+       </a>
+       comprend, pour chaque substance, sa concentration et son flux, pour chacune des mesures réalisées. Le
+       <a data-spec="section_reference" data-type="tableau">
+        tableau
+       </a>
+       comprend également les concentrations minimale, maximale et moyenne mesurées sur les six échantillons, ainsi que les flux minimal, maximal et moyen calculés à partir des six mesures et les limites de quantification pour chaque mesure;
       </li>
       <li>
        - L'ensemble des rapports d'analyses réalisées en application du
@@ -5403,8 +5419,12 @@ RÉPUBLIQUE FRANÇAISE
       <a data-spec="section_reference" data-start_num="10" data-type="annexe">
        annexe X
       </a>
-      de la DCE (tableau A de la
-      <a data-date="2007-05-07" data-spec="document_reference" data-type="circulaire">
+      de la DCE (
+      <a data-parent_reference="18" data-spec="section_reference" data-type="tableau">
+       tableau
+      </a>
+      A de la
+      <a data-date="2007-05-07" data-spec="document_reference" data-tag_id="18" data-type="circulaire">
        circulaire du
        <time data-spec="date" datetime="2007-05-07">
         07/05/07
@@ -5417,8 +5437,12 @@ RÉPUBLIQUE FRANÇAISE
       <a data-spec="section_reference" data-start_num="10" data-type="annexe">
        annexe X
       </a>
-      de la DCE (tableau A de la
-      <a data-date="2007-05-07" data-spec="document_reference" data-type="circulaire">
+      de la DCE (
+      <a data-parent_reference="19" data-spec="section_reference" data-type="tableau">
+       tableau
+      </a>
+      A de la
+      <a data-date="2007-05-07" data-spec="document_reference" data-tag_id="19" data-type="circulaire">
        circulaire du
        <time data-spec="date" datetime="2007-05-07">
         07/05/07
@@ -5428,19 +5452,23 @@ RÉPUBLIQUE FRANÇAISE
      </div>
      <div data-number="6" data-spec="alinea">
       Autres substances pertinentes issues de la liste I de la
-      <a data-date="2006" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374" data-num="11" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374">
+      <a data-date="2006" data-num="11" data-spec="document_reference" data-type="eu-directive">
        directive 2006/11/CE
       </a>
       (anciennement
-      <a data-date="1976" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:2efc093a-eba8-4834-8ae6-c91d6c47db78" data-num="464" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:2efc093a-eba8-4834-8ae6-c91d6c47db78">
+      <a data-date="1976" data-num="464" data-spec="document_reference" data-type="eu-directive">
        Directive 76/464/CEE
       </a>
       ) et ne figurant pas à l'
       <a data-spec="section_reference" data-start_num="10" data-type="annexe">
        annexe X
       </a>
-      de la DCE (tableau B de la
-      <a data-date="2007-05-07" data-spec="document_reference" data-type="circulaire">
+      de la DCE (
+      <a data-parent_reference="20" data-spec="section_reference" data-type="tableau">
+       tableau
+      </a>
+      B de la
+      <a data-date="2007-05-07" data-spec="document_reference" data-tag_id="20" data-type="circulaire">
        circulaire du
        <time data-spec="date" datetime="2007-05-07">
         07/05/07
@@ -5450,15 +5478,19 @@ RÉPUBLIQUE FRANÇAISE
      </div>
      <div data-number="7" data-spec="alinea">
       Autres substances pertinentes issues de la liste II de la
-      <a data-date="2006" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374" data-num="11" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374">
+      <a data-date="2006" data-num="11" data-spec="document_reference" data-type="eu-directive">
        directive 2006/11/CE
       </a>
       (anciennement
-      <a data-date="1976" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:2efc093a-eba8-4834-8ae6-c91d6c47db78" data-num="464" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:2efc093a-eba8-4834-8ae6-c91d6c47db78">
+      <a data-date="1976" data-num="464" data-spec="document_reference" data-type="eu-directive">
        Directive 76/464/CEE
       </a>
-      ) et autres substances, non SDP ni SP (tableaux D et E de la
-      <a data-date="2007-05-07" data-spec="document_reference" data-type="circulaire">
+      ) et autres substances, non SDP ni SP (
+      <a data-parent_reference="21" data-spec="section_reference" data-type="tableau">
+       tableaux
+      </a>
+      D et E de la
+      <a data-date="2007-05-07" data-spec="document_reference" data-tag_id="21" data-type="circulaire">
        circulaire du
        <time data-spec="date" datetime="2007-05-07">
         07/05/07
@@ -7953,7 +7985,15 @@ RÉPUBLIQUE FRANÇAISE
        2. Liste de références en matière d'opérations de prélèvements de substances dangereuses dans les rejets industriels
       </h4>
       <div data-number="1" data-spec="alinea">
-       3. Tableau des performances et d'assurance qualité à renseigner obligatoirement : les critères de choix pour l'exploitant pour la sélection d'un laboratoire prestataire sont repris dans ce tableau : substance accréditée ou non, et limite de quantification qui doivent être inférieures ou égales aux LQ de l'
+       3.
+       <a data-spec="section_reference" data-type="tableau">
+        Tableau
+       </a>
+       des performances et d'assurance qualité à renseigner obligatoirement : les critères de choix pour l'exploitant pour la sélection d'un laboratoire prestataire sont repris dans ce
+       <a data-spec="section_reference" data-type="tableau">
+        tableau
+       </a>
+       : substance accréditée ou non, et limite de quantification qui doivent être inférieures ou égales aux LQ de l'
        <a data-spec="section_reference" data-start_num="5.2" data-type="annexe">
         annexe 5.2.
        </a>

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005800425/2010-03-29.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005800425/2010-03-29.html
@@ -290,14 +290,14 @@ RÉPUBLIQUE FRANÇAISE
    </div>
    <div data-spec="visa">
     Vu la
-    <a data-date="2006" data-num="11" data-spec="document_reference" data-type="eu-directive">
+    <a data-date="2006" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374" data-num="11" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374">
      directive 2006/11/CE
     </a>
     concernant la pollution causée par certaines substances dangereuses déversées dans le milieu aquatique de la Communauté ;
    </div>
    <div data-spec="visa">
     Vu la
-    <a data-date="2000" data-num="60" data-spec="document_reference" data-type="eu-directive">
+    <a data-date="2000" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb" data-num="60" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb">
      directive 2000/60/CE
     </a>
     du 23 octobre 2000 établissant un cadre pour une politique communautaire dans le domaine de l'eau (DCE) ;
@@ -452,7 +452,7 @@ RÉPUBLIQUE FRANÇAISE
    </div>
    <div data-spec="motifs">
     Considérant l'objectif de respect des normes de qualité environnementale dans le milieu en 2015 fixé par la
-    <a data-date="2000" data-num="60" data-spec="document_reference" data-type="eu-directive">
+    <a data-date="2000" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb" data-num="60" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:5c835afb-2ec6-4577-bdf8-756d3d694eeb">
      directive 2000/60/CE
     </a>
     ;
@@ -5452,11 +5452,11 @@ RÉPUBLIQUE FRANÇAISE
      </div>
      <div data-number="6" data-spec="alinea">
       Autres substances pertinentes issues de la liste I de la
-      <a data-date="2006" data-num="11" data-spec="document_reference" data-type="eu-directive">
+      <a data-date="2006" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374" data-num="11" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374">
        directive 2006/11/CE
       </a>
       (anciennement
-      <a data-date="1976" data-num="464" data-spec="document_reference" data-type="eu-directive">
+      <a data-date="1976" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:2efc093a-eba8-4834-8ae6-c91d6c47db78" data-num="464" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:2efc093a-eba8-4834-8ae6-c91d6c47db78">
        Directive 76/464/CEE
       </a>
       ) et ne figurant pas à l'
@@ -5478,7 +5478,7 @@ RÉPUBLIQUE FRANÇAISE
      </div>
      <div data-number="7" data-spec="alinea">
       Autres substances pertinentes issues de la liste II de la
-      <a data-date="2006" data-num="11" data-spec="document_reference" data-type="eu-directive">
+      <a data-date="2006" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374" data-num="11" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:4ea4e474-3ca0-4c40-8a60-d47a2470b374">
        directive 2006/11/CE
       </a>
       (anciennement

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005800425/2010-03-29.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005800425/2010-03-29.html
@@ -5482,7 +5482,7 @@ RÉPUBLIQUE FRANÇAISE
        directive 2006/11/CE
       </a>
       (anciennement
-      <a data-date="1976" data-num="464" data-spec="document_reference" data-type="eu-directive">
+      <a data-date="1976" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:2efc093a-eba8-4834-8ae6-c91d6c47db78" data-num="464" data-spec="document_reference" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:2efc093a-eba8-4834-8ae6-c91d6c47db78">
        Directive 76/464/CEE
       </a>
       ) et autres substances, non SDP ni SP (

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005800425/2012-09-03.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005800425/2012-09-03.html
@@ -514,13 +514,13 @@ RÉPUBLIQUE FRANÇAISE
     </h2>
     <div data-number="1" data-spec="alinea">
      Les dispositions de l'
-     <a data-date="2007-04-19" data-num="D3-B4-07-86" data-spec="document_reference" data-tag_id="10" data-type="arrete-prefectoral">
+     <a data-date="2007-04-19" data-num="D3-B4-07-86" data-spec="document_reference" data-tag_id="11" data-type="arrete-prefectoral">
       arrêté préfectoral n° D3-B4-07-86 du
       <time data-spec="date" datetime="2007-04-19">
        19 avril 2007
       </time>
      </a>
-     <span data-direction="rtl" data-keyword="supprimées" data-operation_type="delete" data-references="10" data-spec="operation">
+     <span data-direction="rtl" data-keyword="supprimées" data-operation_type="delete" data-references="11" data-spec="operation">
       réglementant des activités de la société RECTICEL sise à Louviers et qui exploite un établissement de fabrication de mousse de polyuréthane sont
       <b>
        supprimées
@@ -535,13 +535,13 @@ RÉPUBLIQUE FRANÇAISE
     </h2>
     <div data-number="1" data-spec="alinea">
      Les dispositions de l'
-     <a data-date="2005-11-08" data-spec="document_reference" data-tag_id="11" data-type="arrete-prefectoral">
+     <a data-date="2005-11-08" data-spec="document_reference" data-tag_id="12" data-type="arrete-prefectoral">
       arrêté préfectoral du
       <time data-spec="date" datetime="2005-11-08">
        08 novembre 2005
       </time>
      </a>
-     <span data-direction="rtl" data-has_operand="true" data-keyword="modifiées" data-operation_type="replace" data-references="11" data-spec="operation">
+     <span data-direction="rtl" data-has_operand="true" data-keyword="modifiées" data-operation_type="replace" data-references="12" data-spec="operation">
       réglementant les activités de la société RECTICEL SAS, rue de la Mécanique, 27460 LOUVIERS (et dont le siège social est implanté 7, rue du Fossé Blanc – 92622 GENNEVILLIERS) sont
       <b>
        modifiées
@@ -555,11 +555,15 @@ RÉPUBLIQUE FRANÇAISE
      Article 3 :
     </h2>
     <div data-number="1" data-spec="alinea">
-     Le tableau de l'
-     <a data-spec="section_reference" data-start_num="1.2" data-tag_id="12" data-type="article">
+     Le
+     <a data-parent_reference="3" data-spec="section_reference" data-tag_id="13" data-type="tableau">
+      tableau
+     </a>
+     de l'
+     <a data-spec="section_reference" data-start_num="1.2" data-tag_id="3" data-type="article">
       article 1.2
      </a>
-     <span data-direction="rtl" data-keyword="supprimé" data-operation_type="delete" data-references="12" data-spec="operation">
+     <span data-direction="rtl" data-keyword="supprimé" data-operation_type="delete" data-references="13" data-spec="operation">
       – Liste des installations est
       <b>
        supprimé
@@ -907,19 +911,23 @@ RÉPUBLIQUE FRANÇAISE
     </h2>
     <div data-number="1" data-spec="alinea">
      Les dispositions de l'
-     <a data-spec="section_reference" data-start_num="2.7" data-tag_id="13" data-type="article">
+     <a data-spec="section_reference" data-start_num="2.7" data-tag_id="14" data-type="article">
       article 2.7
      </a>
-     <span data-direction="rtl" data-has_operand="true" data-keyword="remplacées" data-operand="14" data-operation_type="replace" data-references="13" data-spec="operation">
+     <span data-direction="rtl" data-has_operand="true" data-keyword="remplacées" data-operation_type="replace" data-references="14" data-spec="operation">
       – Réglementation générale – Arrêtés ministériels sont supprimées. Elles sont
       <b>
        remplacées
       </b>
-      par celles inscrites dans le tableau suivant :
+      par celles inscrites dans le
      </span>
+     <a data-spec="section_reference" data-type="tableau">
+      tableau
+     </a>
+     suivant :
     </div>
     <div data-number="2" data-spec="alinea">
-     <table data-tag_id="14">
+     <table>
       <tr>
        <th>
         Dates
@@ -997,15 +1005,15 @@ RÉPUBLIQUE FRANÇAISE
        </td>
        <td>
         Arrêté relatif à la déclaration annuelle à l'administration, pris en application des
-        <a data-group_id="2" data-parent_reference="3" data-spec="section_reference" data-start_num="3" data-type="article">
+        <a data-group_id="2" data-parent_reference="4" data-spec="section_reference" data-start_num="3" data-type="article">
          articles 3
         </a>
         et
-        <a data-group_id="2" data-parent_reference="3" data-spec="section_reference" data-start_num="5" data-type="article">
+        <a data-group_id="2" data-parent_reference="4" data-spec="section_reference" data-start_num="5" data-type="article">
          5
         </a>
         du
-        <a data-date="2005-05-30" data-id="JORFTEXT000000257088" data-num="2005-635" data-spec="document_reference" data-tag_id="3" data-type="decret" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000000257088">
+        <a data-date="2005-05-30" data-id="JORFTEXT000000257088" data-num="2005-635" data-spec="document_reference" data-tag_id="4" data-type="decret" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000000257088">
          décret n° 2005-635 du
          <time data-spec="date" datetime="2005-05-30">
           30 mai 2005
@@ -1020,11 +1028,11 @@ RÉPUBLIQUE FRANÇAISE
        </td>
        <td>
         Arrêté relatif aux modalités de traitement des déchets d'équipements électriques et électroniques prévues à l'
-        <a data-parent_reference="4" data-spec="section_reference" data-start_num="21" data-type="article">
+        <a data-parent_reference="5" data-spec="section_reference" data-start_num="21" data-type="article">
          article 21
         </a>
         du
-        <a data-date="2005-07-20" data-id="JORFTEXT000000810278" data-num="2005-829" data-spec="document_reference" data-tag_id="4" data-type="decret" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000000810278">
+        <a data-date="2005-07-20" data-id="JORFTEXT000000810278" data-num="2005-829" data-spec="document_reference" data-tag_id="5" data-type="decret" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000000810278">
          décret n° 2005-829 du
          <time data-spec="date" datetime="2005-07-20">
           20 juillet 2005
@@ -1039,11 +1047,11 @@ RÉPUBLIQUE FRANÇAISE
        </td>
        <td>
         Arrêté relatif à la déclaration annuelle à l'administration des installations de stockage de déchets inertes mentionnée à l'
-        <a data-parent_reference="5" data-spec="section_reference" data-start_num="5" data-type="article">
+        <a data-parent_reference="6" data-spec="section_reference" data-start_num="5" data-type="article">
          article 5
         </a>
         du
-        <a data-date="2005-05-30" data-id="JORFTEXT000000257088" data-num="2005-635" data-spec="document_reference" data-tag_id="5" data-type="decret" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000000257088">
+        <a data-date="2005-05-30" data-id="JORFTEXT000000257088" data-num="2005-635" data-spec="document_reference" data-tag_id="6" data-type="decret" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000000257088">
          décret n° 2005-635 du
          <time data-spec="date" datetime="2005-05-30">
           30 mai 2005
@@ -1066,11 +1074,11 @@ RÉPUBLIQUE FRANÇAISE
        </td>
        <td>
         Arrêté fixant le formulaire de bordereau de suivi de déchets dangereux mentionné à l'
-        <a data-parent_reference="6" data-spec="section_reference" data-start_num="4" data-type="article">
+        <a data-parent_reference="7" data-spec="section_reference" data-start_num="4" data-type="article">
          article 4
         </a>
         du
-        <a data-date="2005-05-30" data-id="JORFTEXT000000257088" data-num="2005-635" data-spec="document_reference" data-tag_id="6" data-type="decret" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000000257088">
+        <a data-date="2005-05-30" data-id="JORFTEXT000000257088" data-num="2005-635" data-spec="document_reference" data-tag_id="7" data-type="decret" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000000257088">
          décret n° 2005-635 du
          <time data-spec="date" datetime="2005-05-30">
           30 mai 2005
@@ -1085,11 +1093,11 @@ RÉPUBLIQUE FRANÇAISE
        </td>
        <td>
         Arrêté fixant le contenu des registres mentionnés à l'
-        <a data-parent_reference="7" data-spec="section_reference" data-start_num="2" data-type="article">
+        <a data-parent_reference="8" data-spec="section_reference" data-start_num="2" data-type="article">
          article 2
         </a>
         du
-        <a data-date="2005-05-30" data-id="JORFTEXT000000257088" data-num="2005-635" data-spec="document_reference" data-tag_id="7" data-type="decret" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000000257088">
+        <a data-date="2005-05-30" data-id="JORFTEXT000000257088" data-num="2005-635" data-spec="document_reference" data-tag_id="8" data-type="decret" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000000257088">
          décret n° 2005-635 du
          <time data-spec="date" datetime="2005-05-30">
           30 mai 2005
@@ -1181,16 +1189,20 @@ RÉPUBLIQUE FRANÇAISE
      <a data-spec="section_reference" data-start_num="2.8" data-tag_id="15" data-type="article">
       article 2.8
      </a>
-     <span data-direction="rtl" data-has_operand="true" data-keyword="supprimées et sont remplacées" data-operand="16" data-operation_type="replace" data-references="15" data-spec="operation">
+     <span data-direction="rtl" data-has_operand="true" data-keyword="supprimées et sont remplacées" data-operation_type="replace" data-references="15" data-spec="operation">
       – Arrêtés types sont
       <b>
        supprimées et sont remplacées
       </b>
-      par celles du tableau suivant :
+      par celles du
      </span>
+     <a data-spec="section_reference" data-type="tableau">
+      tableau
+     </a>
+     suivant :
     </div>
     <div data-number="2" data-spec="alinea">
-     <table data-tag_id="16">
+     <table>
       <tr>
        <th>
         Dates
@@ -1232,10 +1244,10 @@ RÉPUBLIQUE FRANÇAISE
     </h2>
     <div data-number="1" data-spec="alinea">
      Les dispositions du
-     <a data-spec="section_reference" data-start_num="3.1.9" data-tag_id="17" data-type="unknown">
+     <a data-spec="section_reference" data-start_num="3.1.9" data-tag_id="16" data-type="unknown">
       paragraphe 3.1.9
      </a>
-     <span data-direction="rtl" data-has_operand="true" data-keyword="complétées" data-operation_type="add" data-references="17" data-spec="operation">
+     <span data-direction="rtl" data-has_operand="true" data-keyword="complétées" data-operation_type="add" data-references="16" data-spec="operation">
       – Confinement sont
       <b>
        complétées
@@ -1272,10 +1284,10 @@ RÉPUBLIQUE FRANÇAISE
     </h2>
     <div data-number="1" data-spec="alinea">
      Les dispositions du
-     <a data-spec="section_reference" data-start_num="4.2" data-tag_id="18" data-type="unknown">
+     <a data-spec="section_reference" data-start_num="4.2" data-tag_id="17" data-type="unknown">
       paragraphe 4.2
      </a>
-     <span data-direction="rtl" data-has_operand="true" data-keyword="remplacées" data-operation_type="replace" data-references="18" data-spec="operation">
+     <span data-direction="rtl" data-has_operand="true" data-keyword="remplacées" data-operation_type="replace" data-references="17" data-spec="operation">
       – Zones de dangers sont supprimées. Elles sont
       <b>
        remplacées
@@ -1284,7 +1296,11 @@ RÉPUBLIQUE FRANÇAISE
      </span>
     </div>
     <div data-number="2" data-spec="alinea">
-     Les données (distances ...) des effets toxiques susceptibles de sortir du site sont reprises dans le tableau suivant :
+     Les données (distances ...) des effets toxiques susceptibles de sortir du site sont reprises dans le
+     <a data-spec="section_reference" data-type="tableau">
+      tableau
+     </a>
+     suivant :
     </div>
     <div data-number="3" data-spec="alinea">
      <table>
@@ -1400,7 +1416,11 @@ RÉPUBLIQUE FRANÇAISE
      </div>
     </div>
     <div data-number="6" data-spec="alinea">
-     Les données (distances ...) des flux thermiques susceptibles de sortir du site sont reprises dans le tableau suivant :
+     Les données (distances ...) des flux thermiques susceptibles de sortir du site sont reprises dans le
+     <a data-spec="section_reference" data-type="tableau">
+      tableau
+     </a>
+     suivant :
     </div>
     <div data-number="7" data-spec="alinea">
      <table>
@@ -1527,11 +1547,11 @@ RÉPUBLIQUE FRANÇAISE
     </div>
     <div data-number="12" data-spec="alinea">
      L'exploitant doit intégrer ces éléments dans le POI visé à l'
-     <a data-parent_reference="8" data-spec="section_reference" data-start_num="13" data-type="article">
+     <a data-parent_reference="9" data-spec="section_reference" data-start_num="13" data-type="article">
       article 13
      </a>
      du
-     <a data-spec="document_reference" data-tag_id="8" data-type="self">
+     <a data-spec="document_reference" data-tag_id="9" data-type="self">
       présent arrêté
      </a>
      .
@@ -1543,10 +1563,10 @@ RÉPUBLIQUE FRANÇAISE
     </h2>
     <div data-number="1" data-spec="alinea">
      Le contenu du
-     <a data-spec="section_reference" data-start_num="4.6" data-tag_id="19" data-type="unknown">
+     <a data-spec="section_reference" data-start_num="4.6" data-tag_id="18" data-type="unknown">
       paragraphe 4.6
      </a>
-     <span data-direction="rtl" data-keyword="supprimé" data-operation_type="delete" data-references="19" data-spec="operation">
+     <span data-direction="rtl" data-keyword="supprimé" data-operation_type="delete" data-references="18" data-spec="operation">
       – Equipements et paramètres de fonctionnement importants pour la sécurité est
       <b>
        supprimé
@@ -1598,10 +1618,10 @@ RÉPUBLIQUE FRANÇAISE
     </h2>
     <div data-number="1" data-spec="alinea">
      Les dispositions du
-     <a data-spec="section_reference" data-start_num="4.8" data-tag_id="20" data-type="unknown">
+     <a data-spec="section_reference" data-start_num="4.8" data-tag_id="19" data-type="unknown">
       paragraphe 4.8
      </a>
-     <span data-direction="rtl" data-has_operand="true" data-keyword="remplacées" data-operation_type="replace" data-references="20" data-spec="operation">
+     <span data-direction="rtl" data-has_operand="true" data-keyword="remplacées" data-operation_type="replace" data-references="19" data-spec="operation">
       – Caractéristiques et aménagement sont supprimées. Elles sont
       <b>
        remplacées
@@ -1613,7 +1633,11 @@ RÉPUBLIQUE FRANÇAISE
      L'exploitant implante des murs coupe-feu 2 heures dans les locaux à risques.
     </div>
     <div data-number="3" data-spec="alinea">
-     A minima, les murs coupe-feu sont ceux repris dans le tableau suivant :
+     A minima, les murs coupe-feu sont ceux repris dans le
+     <a data-spec="section_reference" data-type="tableau">
+      tableau
+     </a>
+     suivant :
     </div>
     <div data-number="4" data-spec="alinea">
      <table>
@@ -1699,10 +1723,10 @@ RÉPUBLIQUE FRANÇAISE
     </h2>
     <div data-number="1" data-spec="alinea">
      Le
-     <a data-spec="section_reference" data-start_num="4.14" data-tag_id="21" data-type="unknown">
+     <a data-spec="section_reference" data-start_num="4.14" data-tag_id="20" data-type="unknown">
       paragraphe 4.14
      </a>
-     <span data-direction="rtl" data-has_operand="true" data-keyword="complété" data-operation_type="add" data-references="21" data-spec="operation">
+     <span data-direction="rtl" data-has_operand="true" data-keyword="complété" data-operation_type="add" data-references="20" data-spec="operation">
       – Postes de chargement -déchargement est
       <b>
        complété
@@ -1757,10 +1781,10 @@ RÉPUBLIQUE FRANÇAISE
     </h2>
     <div data-number="1" data-spec="alinea">
      Le
-     <a data-spec="section_reference" data-start_num="4.19.1" data-tag_id="22" data-type="unknown">
+     <a data-spec="section_reference" data-start_num="4.19.1" data-tag_id="21" data-type="unknown">
       paragraphe 4.19.1
      </a>
-     <span data-direction="rtl" data-has_operand="true" data-keyword="complété" data-operation_type="add" data-references="22" data-spec="operation">
+     <span data-direction="rtl" data-has_operand="true" data-keyword="complété" data-operation_type="add" data-references="21" data-spec="operation">
       – Réseau d'eau incendie est
       <b>
        complété
@@ -1819,11 +1843,11 @@ RÉPUBLIQUE FRANÇAISE
       article 1er
      </a>
      du décret 2005-1158 du 13 septembre 2005 et de l'
-     <a data-parent_reference="9" data-spec="section_reference" data-start_id="LEGIARTI000031624415" data-start_num="R512-29" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031624415">
+     <a data-parent_reference="10" data-spec="section_reference" data-start_id="LEGIARTI000031624415" data-start_num="R512-29" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031624415">
       article R 512-29
      </a>
      du
-     <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="9" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+     <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="10" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
       code de l'environnement
      </a>
      .
@@ -1832,10 +1856,10 @@ RÉPUBLIQUE FRANÇAISE
      Le POI est homogène avec la nature et les enveloppes des différents phénomènes de dangers envisagés dans les études de dangers. Un exemplaire du POI doit être disponible en permanence sur l'emplacement prévu pour y installer le poste de commandement.
     </div>
     <div data-number="9" data-spec="alinea">
-     <a data-spec="section_reference" data-start_num="4.25" data-tag_id="23" data-type="unknown">
+     <a data-spec="section_reference" data-start_num="4.25" data-tag_id="22" data-type="unknown">
       Paragraphe 4.25
      </a>
-     <span data-direction="rtl" data-has_operand="true" data-keyword="ajouté" data-operation_type="add" data-references="23" data-spec="operation">
+     <span data-direction="rtl" data-has_operand="true" data-keyword="ajouté" data-operation_type="add" data-references="22" data-spec="operation">
       – Cuves de stockages de TDI/MDI. Il est
       <b>
        ajouté
@@ -1995,10 +2019,10 @@ RÉPUBLIQUE FRANÇAISE
     </div>
     <div data-number="28" data-spec="alinea">
      .
-     <a data-spec="section_reference" data-start_num="4.28" data-tag_id="24" data-type="unknown">
+     <a data-spec="section_reference" data-start_num="4.28" data-tag_id="23" data-type="unknown">
       Paragraphe 4.28
      </a>
-     <span data-direction="rtl" data-has_operand="true" data-keyword="ajouté" data-operation_type="add" data-references="24" data-spec="operation">
+     <span data-direction="rtl" data-has_operand="true" data-keyword="ajouté" data-operation_type="add" data-references="23" data-spec="operation">
       – Information des secours. Il est
       <b>
        ajouté
@@ -2031,10 +2055,10 @@ RÉPUBLIQUE FRANÇAISE
     </div>
     <div data-number="31" data-spec="alinea">
      .
-     <a data-spec="section_reference" data-start_num="4.29" data-tag_id="25" data-type="unknown">
+     <a data-spec="section_reference" data-start_num="4.29" data-tag_id="24" data-type="unknown">
       Paragraphe 4.29
      </a>
-     <span data-direction="rtl" data-has_operand="true" data-keyword="ajouté" data-operation_type="add" data-references="25" data-spec="operation">
+     <span data-direction="rtl" data-has_operand="true" data-keyword="ajouté" data-operation_type="add" data-references="24" data-spec="operation">
       – Efficacité énergétique. Lutte contre les gaz à effet de serre et pollution lumineuse. Il est
       <b>
        ajouté

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005804239/2009-12-08.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005804239/2009-12-08.html
@@ -5104,7 +5104,7 @@ RÉPUBLIQUE FRANÇAISE
         annexes II
        </a>
        -A et II-B de la
-       <a data-date="2006" data-num="12" data-spec="document_reference" data-tag_id="25" data-type="eu-directive">
+       <a data-date="2006" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:0f484039-4061-4922-9739-76d173d0d919" data-num="12" data-spec="document_reference" data-tag_id="25" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:0f484039-4061-4922-9739-76d173d0d919">
         directive 2006/12/CE
        </a>
        du 05 avril 2006.

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005804239/2009-12-08.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005804239/2009-12-08.html
@@ -5211,7 +5211,7 @@ RÉPUBLIQUE FRANÇAISE
      </div>
      <div data-number="3" data-spec="alinea">
       L'importation ou l'exportation de déchets ne peut être réalisée qu'après accord des autorités compétentes en application du
-      <a data-date="2006" data-num="1013" data-spec="document_reference" data-type="eu-regulation">
+      <a data-date="2006" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:1784c89a-69e5-43eb-9c40-1157f6895e85" data-num="1013" data-spec="document_reference" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:1784c89a-69e5-43eb-9c40-1157f6895e85">
        règlement (CE) n° 1013/2006
       </a>
       du parlement européen et du conseil du 14 juin 2006 concernant les transferts de déchets.

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005804239/2009-12-08.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005804239/2009-12-08.html
@@ -3913,7 +3913,11 @@ RÉPUBLIQUE FRANÇAISE
          - à des conditions normalisées de température (273 kelvins) et de pression (101,3 kilo pascals) après déduction de la vapeur d'eau (gaz secs);
         </li>
         <li>
-         - à une teneur en O₂ ou CO₂ précisée dans le tableau ci-dessous.
+         - à une teneur en O₂ ou CO₂ précisée dans le
+         <a data-spec="section_reference" data-type="tableau">
+          tableau
+         </a>
+         ci-dessous.
         </li>
        </ul>
       </div>
@@ -5100,7 +5104,7 @@ RÉPUBLIQUE FRANÇAISE
         annexes II
        </a>
        -A et II-B de la
-       <a data-date="2006" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:0f484039-4061-4922-9739-76d173d0d919" data-num="12" data-spec="document_reference" data-tag_id="25" data-type="eu-directive" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:0f484039-4061-4922-9739-76d173d0d919">
+       <a data-date="2006" data-num="12" data-spec="document_reference" data-tag_id="25" data-type="eu-directive">
         directive 2006/12/CE
        </a>
        du 05 avril 2006.
@@ -5207,7 +5211,7 @@ RÉPUBLIQUE FRANÇAISE
      </div>
      <div data-number="3" data-spec="alinea">
       L'importation ou l'exportation de déchets ne peut être réalisée qu'après accord des autorités compétentes en application du
-      <a data-date="2006" data-id="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:1784c89a-69e5-43eb-9c40-1157f6895e85" data-num="1013" data-spec="document_reference" data-type="eu-regulation" href="https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=cellar:1784c89a-69e5-43eb-9c40-1157f6895e85">
+      <a data-date="2006" data-num="1013" data-spec="document_reference" data-type="eu-regulation">
        règlement (CE) n° 1013/2006
       </a>
       du parlement européen et du conseil du 14 juin 2006 concernant les transferts de déchets.
@@ -6085,12 +6089,16 @@ RÉPUBLIQUE FRANÇAISE
         Article 9.2.1.3. Surveillance de la composition des composés organiques volatils
        </h5>
        <div data-number="1" data-spec="alinea">
-        Dans le cas où le flux horaire de composés organiques volatils (émissions canalisées et diffuses dont les fugitives) visés dans le tableau de l'
-        <a data-parent_reference="33" data-spec="section_reference" data-start_num="3" data-type="annexe">
+        Dans le cas où le flux horaire de composés organiques volatils (émissions canalisées et diffuses dont les fugitives) visés dans le
+        <a data-parent_reference="33" data-spec="section_reference" data-type="tableau">
+         tableau
+        </a>
+        de l'
+        <a data-parent_reference="34" data-spec="section_reference" data-start_num="3" data-tag_id="33" data-type="annexe">
          annexe III
         </a>
         de l'
-        <a data-date="1998-02-02" data-spec="document_reference" data-tag_id="33" data-type="arrete-ministeriel">
+        <a data-date="1998-02-02" data-spec="document_reference" data-tag_id="34" data-type="arrete-ministeriel">
          arrêté ministériel du
          <time data-spec="date" datetime="1998-02-02">
           2 février 1998
@@ -6352,11 +6360,11 @@ RÉPUBLIQUE FRANÇAISE
         <tr>
          <td>
           Substances très toxiques pour l'environnement aquatique visées à l'
-          <a data-parent_reference="34" data-spec="section_reference" data-start_num="V.a" data-type="annexe">
+          <a data-parent_reference="35" data-spec="section_reference" data-start_num="V.a" data-type="annexe">
            annexe V.a
           </a>
           de l'
-          <a data-date="1998-02-02" data-spec="document_reference" data-tag_id="34" data-type="arrete-ministeriel">
+          <a data-date="1998-02-02" data-spec="document_reference" data-tag_id="35" data-type="arrete-ministeriel">
            arrêté ministériel du
            <time data-spec="date" datetime="1998-02-02">
             2 février 1998
@@ -6377,11 +6385,11 @@ RÉPUBLIQUE FRANÇAISE
         <tr>
          <td>
           Substances toxiques ou néfastes à long terme pour l'environnement aquatique visées à l'
-          <a data-parent_reference="35" data-spec="section_reference" data-start_num="V.b" data-type="annexe">
+          <a data-parent_reference="36" data-spec="section_reference" data-start_num="V.b" data-type="annexe">
            annexe V.b
           </a>
           de l'
-          <a data-date="1998-02-02" data-spec="document_reference" data-tag_id="35" data-type="arrete-ministeriel">
+          <a data-date="1998-02-02" data-spec="document_reference" data-tag_id="36" data-type="arrete-ministeriel">
            arrêté ministériel du
            <time data-spec="date" datetime="1998-02-02">
             2 février 1998
@@ -6403,11 +6411,11 @@ RÉPUBLIQUE FRANÇAISE
         <tr>
          <td>
           Substances nocives pour l'environnement aquatique visées à l'
-          <a data-parent_reference="36" data-spec="section_reference" data-start_num="V.c" data-type="annexe">
+          <a data-parent_reference="37" data-spec="section_reference" data-start_num="V.c" data-type="annexe">
            annexe V.c
           </a>
           1 de l'
-          <a data-date="1998-02-02" data-spec="document_reference" data-tag_id="36" data-type="arrete-ministeriel">
+          <a data-date="1998-02-02" data-spec="document_reference" data-tag_id="37" data-type="arrete-ministeriel">
            arrêté ministériel du
            <time data-spec="date" datetime="1998-02-02">
             2 février 1998
@@ -6428,11 +6436,11 @@ RÉPUBLIQUE FRANÇAISE
         <tr>
          <td>
           Substances susceptibles d'avoir des effets à long terme pour l'environnement aquatique visées à l'
-          <a data-parent_reference="37" data-spec="section_reference" data-start_num="V.c" data-type="annexe">
+          <a data-parent_reference="38" data-spec="section_reference" data-start_num="V.c" data-type="annexe">
            annexe V.c
           </a>
           2 de l'
-          <a data-date="1998-02-02" data-spec="document_reference" data-tag_id="37" data-type="arrete-ministeriel">
+          <a data-date="1998-02-02" data-spec="document_reference" data-tag_id="38" data-type="arrete-ministeriel">
            arrêté ministériel du
            <time data-spec="date" datetime="1998-02-02">
             2 février 1998
@@ -6637,11 +6645,11 @@ RÉPUBLIQUE FRANÇAISE
       </a>
       <div data-number="2" data-spec="alinea">
        En particulier, lorsque la surveillance environnementale sur les eaux souterraines ou les sols fait apparaître une dérive par rapport à l'état initial de l'environnement, soit réalisé en application de l'
-       <a data-parent_reference="38" data-spec="section_reference" data-start_id="LEGIARTI000029774403" data-start_num="R512-8" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000029774403">
+       <a data-parent_reference="39" data-spec="section_reference" data-start_id="LEGIARTI000029774403" data-start_num="R512-8" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000029774403">
         article R512-8
        </a>
        II 1° du
-       <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="38" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+       <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="39" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
         code de l'environnement
        </a>
        soit reconstitué aux fins d'interprétation des résultats de surveillance, l'exploitant met en œuvre les actions de réduction complémentaires des émissions appropriées et met en œuvre, le cas échéant, un plan de gestion visant à rétablir la compatibilité entre les milieux impactés et leurs usages.
@@ -6653,11 +6661,11 @@ RÉPUBLIQUE FRANÇAISE
       </h4>
       <div data-number="1" data-spec="alinea">
        Sans préjudice des dispositions de l'
-       <a data-parent_reference="39" data-spec="section_reference" data-start_id="LEGIARTI000042370894" data-start_num="R512-69" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042370894">
+       <a data-parent_reference="40" data-spec="section_reference" data-start_id="LEGIARTI000042370894" data-start_num="R512-69" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042370894">
         article R.512-69
        </a>
        du
-       <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="39" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+       <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="40" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
         code de l'environnement
        </a>
        , l'exploitant établit un rapport de synthèse relatif aux résultats des mesures représentatives quotidiennes et mensuelles imposées au chapitre 9.2 du mois précédent. Le rapport de synthèse est adressé avant le quinze du mois suivant.
@@ -6759,11 +6767,11 @@ RÉPUBLIQUE FRANÇAISE
        <ul>
         <li>
          - une évaluation des principaux effets actuels sur les intérêts mentionnés à l'
-         <a data-parent_reference="40" data-spec="section_reference" data-start_id="LEGIARTI000043978078" data-start_num="L511-1" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043978078">
+         <a data-parent_reference="41" data-spec="section_reference" data-start_id="LEGIARTI000043978078" data-start_num="L511-1" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043978078">
           article L 511-1
          </a>
          du
-         <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="40" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+         <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="41" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
           code de l'environnement
          </a>
          ;
@@ -6789,11 +6797,11 @@ RÉPUBLIQUE FRANÇAISE
         </li>
         <li>
          - un résumé des accidents et incidents au cours de la période décennale passée qui ont pu porter atteinte aux intérêts mentionnés à l'
-         <a data-parent_reference="41" data-spec="section_reference" data-start_id="LEGIARTI000043978078" data-start_num="L511-1" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043978078">
+         <a data-parent_reference="42" data-spec="section_reference" data-start_id="LEGIARTI000043978078" data-start_num="L511-1" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043978078">
           article L 511-1
          </a>
          du
-         <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="41" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+         <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="42" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
           code de l'environnement
          </a>
          ;
@@ -6832,11 +6840,11 @@ RÉPUBLIQUE FRANÇAISE
       </div>
       <div data-number="2" data-spec="alinea">
        L'exploitant doit avoir à sa disposition des documents lui permettant de connaître la nature et les risques des substances et préparations dangereuses présentes dans les installations, en particulier les fiches de données de sécurité prévues par l'
-       <a data-parent_reference="42" data-spec="section_reference" data-start_id="LEGIARTI000018513110" data-start_num="R231-53" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000018513110">
+       <a data-parent_reference="43" data-spec="section_reference" data-start_id="LEGIARTI000018513110" data-start_num="R231-53" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000018513110">
         article R.231-53
        </a>
        du
-       <a data-id="LEGITEXT000006072050" data-spec="document_reference" data-tag_id="42" data-title="Code du travail" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072050">
+       <a data-id="LEGITEXT000006072050" data-spec="document_reference" data-tag_id="43" data-title="Code du travail" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072050">
         code du travail
        </a>
        . Les incompatibilités entre les substances et préparations, ainsi que les risques particuliers pouvant découler de leur mise en œuvre dans les installations considérées sont précisés dans ces documents. La conception et l'exploitation des installations en tient compte.
@@ -6971,11 +6979,11 @@ RÉPUBLIQUE FRANÇAISE
        </h5>
        <div data-number="1" data-spec="alinea">
         Les dispositions de l'
-        <a data-parent_reference="43" data-spec="section_reference" data-start_num="2" data-type="article">
+        <a data-parent_reference="44" data-spec="section_reference" data-start_num="2" data-type="article">
          article 2
         </a>
         de l'
-        <a data-date="1980-03-31" data-spec="document_reference" data-tag_id="43" data-type="arrete-ministeriel">
+        <a data-date="1980-03-31" data-spec="document_reference" data-tag_id="44" data-type="arrete-ministeriel">
          arrêté ministériel du
          <time data-spec="date" datetime="1980-03-31">
           31 mars 1980
@@ -7001,11 +7009,11 @@ RÉPUBLIQUE FRANÇAISE
        </h5>
        <div data-number="1" data-spec="alinea">
         Considérant qu'une agression par la foudre sur certaines installations classées pourrait être à l'origine d'événements susceptibles de porter atteinte, directement ou indirectement, aux intérêts visés à l'
-        <a data-parent_reference="44" data-spec="section_reference" data-start_id="LEGIARTI000043978078" data-start_num="L511-1" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043978078">
+        <a data-parent_reference="45" data-spec="section_reference" data-start_id="LEGIARTI000043978078" data-start_num="L511-1" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043978078">
          article L. 511-1
         </a>
         du
-        <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="44" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+        <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="45" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
          code de l'environnement
         </a>
         , une analyse du risque foudre est réalisée par un organisme compétent.
@@ -7015,11 +7023,11 @@ RÉPUBLIQUE FRANÇAISE
        </div>
        <div data-number="3" data-spec="alinea">
         Cette analyse est systématiquement mise à jour à l'occasion de modifications notables des installations nécessitant le dépôt d'une nouvelle autorisation au sens de l'
-        <a data-parent_reference="45" data-spec="section_reference" data-start_id="LEGIARTI000027946900" data-start_num="R512-33" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000027946900">
+        <a data-parent_reference="46" data-spec="section_reference" data-start_id="LEGIARTI000027946900" data-start_num="R512-33" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000027946900">
          article R. 512-33
         </a>
         du
-        <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="45" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+        <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="46" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
          code de l'environnement
         </a>
         et à chaque révision de l'étude de dangers ou pour toute modification des installations qui peut avoir des répercussions sur les données d'entrées de l'analyse du risque foudre.
@@ -7066,11 +7074,11 @@ RÉPUBLIQUE FRANÇAISE
       </h4>
       <div data-number="1" data-spec="alinea">
        Les installations présentant un danger important pour les intérêts visés à l'
-       <a data-parent_reference="46" data-spec="section_reference" data-start_id="LEGIARTI000043978078" data-start_num="L511-1" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043978078">
+       <a data-parent_reference="47" data-spec="section_reference" data-start_id="LEGIARTI000043978078" data-start_num="L511-1" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043978078">
         article L.511-1
        </a>
        du
-       <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="46" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+       <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="47" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
         code de l'environnement
        </a>
        sont protégées contre les effets sismiques conformément aux dispositions définies par l'arrêté ministériel en vigueur.
@@ -7803,11 +7811,11 @@ RÉPUBLIQUE FRANÇAISE
          article 1er
         </a>
         du décret 2005-1158 du 13 septembre 2005 et de l'
-        <a data-parent_reference="47" data-spec="section_reference" data-start_id="LEGIARTI000031624415" data-start_num="R512-29" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031624415">
+        <a data-parent_reference="48" data-spec="section_reference" data-start_id="LEGIARTI000031624415" data-start_num="R512-29" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031624415">
          article R.512-29
         </a>
         du
-        <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="47" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
+        <a data-id="LEGITEXT000006074220" data-spec="document_reference" data-tag_id="48" data-title="Code de l'environnement" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006074220">
          code de l'environnement
         </a>
         . Notamment, l'exploitant doit informer les riverains LBC SOGESTROL, TSN, PMS SERMI, CARE, ARNAL ET FILS.

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005804239/2012-04-02.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005804239/2012-04-02.html
@@ -563,17 +563,21 @@ PRESCRIPTIONS ANNEXÉES À L'ARRÊTÉ PRÉFECTORAL en date du 2 AVR. 2012
       <a data-spec="document_reference" data-type="self">
        présent arrêté
       </a>
-      , sur le territoire de la commune de GONFREVILLE L'ORCHER, vaut pour les installations désignées dans le tableau ci-dessous, incluses dans le périmètre de l'établissement visé en en-tête.
+      , sur le territoire de la commune de GONFREVILLE L'ORCHER, vaut pour les installations désignées dans le
+      <a data-spec="section_reference" data-type="tableau">
+       tableau
+      </a>
+      ci-dessous, incluses dans le périmètre de l'établissement visé en en-tête.
      </div>
      <div data-number="2" data-spec="alinea">
       Les prescriptions techniques de l'
-      <a data-date="2009-12-08" data-spec="document_reference" data-tag_id="19" data-type="arrete-prefectoral">
+      <a data-date="2009-12-08" data-spec="document_reference" data-tag_id="20" data-type="arrete-prefectoral">
        arrêté préfectoral du
        <time data-spec="date" datetime="2009-12-08">
         8 décembre 2009
        </time>
       </a>
-      <span data-direction="rtl" data-has_operand="true" data-keyword="complétées" data-operation_type="add" data-references="19" data-spec="operation">
+      <span data-direction="rtl" data-has_operand="true" data-keyword="complétées" data-operation_type="add" data-references="20" data-spec="operation">
        sont
        <b>
         complétées
@@ -590,18 +594,22 @@ PRESCRIPTIONS ANNEXÉES À L'ARRÊTÉ PRÉFECTORAL en date du 2 AVR. 2012
        1.1.1. Liste des installations
       </h4>
       <div data-number="1" data-spec="alinea">
-       Le tableau de l'
-       <a data-parent_reference="5" data-spec="section_reference" data-start_num="1.2.1" data-tag_id="20" data-type="article">
+       Le
+       <a data-parent_reference="5" data-spec="section_reference" data-tag_id="21" data-type="tableau">
+        tableau
+       </a>
+       de l'
+       <a data-parent_reference="6" data-spec="section_reference" data-start_num="1.2.1" data-tag_id="5" data-type="article">
         article 1.2.1
        </a>
        de l'
-       <a data-date="2009-12-08" data-spec="document_reference" data-tag_id="5" data-type="arrete-prefectoral">
+       <a data-date="2009-12-08" data-spec="document_reference" data-tag_id="6" data-type="arrete-prefectoral">
         arrêté préfectoral du
         <time data-spec="date" datetime="2009-12-08">
          8 décembre 2009
         </time>
        </a>
-       <span data-direction="rtl" data-has_operand="true" data-keyword="complété" data-operand="21" data-operation_type="add" data-references="20" data-spec="operation">
+       <span data-direction="rtl" data-has_operand="true" data-keyword="complété" data-operand="22" data-operation_type="add" data-references="21" data-spec="operation">
         est
         <b>
          complété
@@ -610,7 +618,7 @@ PRESCRIPTIONS ANNEXÉES À L'ARRÊTÉ PRÉFECTORAL en date du 2 AVR. 2012
        </span>
       </div>
       <div data-number="2" data-spec="alinea">
-       <table data-tag_id="21">
+       <table data-tag_id="22">
         <tr>
          <th>
           Rubrique
@@ -635,11 +643,11 @@ PRESCRIPTIONS ANNEXÉES À L'ARRÊTÉ PRÉFECTORAL en date du 2 AVR. 2012
            article 28
           </a>
           de la loi n° 2006-686 du 13 juin 2006 relative à la transparence et à la sécurité en matière nucléaire et des installations nucléaires de base secrètes telles que définies par l'
-          <a data-parent_reference="6" data-spec="section_reference" data-start_num="6" data-type="article">
+          <a data-parent_reference="7" data-spec="section_reference" data-start_num="6" data-type="article">
            article 6
           </a>
           du
-          <a data-date="2001-07-05" data-id="JORFTEXT000000406806" data-num="2001-592" data-spec="document_reference" data-tag_id="6" data-type="decret" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000000406806">
+          <a data-date="2001-07-05" data-id="JORFTEXT000000406806" data-num="2001-592" data-spec="document_reference" data-tag_id="7" data-type="decret" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000000406806">
            décret n° 2001-592 du
            <time data-spec="date" datetime="2001-07-05">
             5 juillet 2001
@@ -673,14 +681,18 @@ PRESCRIPTIONS ANNEXÉES À L'ARRÊTÉ PRÉFECTORAL en date du 2 AVR. 2012
         Le présent arrêté
        </a>
        vaut autorisation au sens de l'
-       <a data-parent_reference="7" data-spec="section_reference" data-start_num="L1333-4" data-type="article" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072665">
+       <a data-parent_reference="8" data-spec="section_reference" data-start_num="L1333-4" data-type="article" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072665">
         article L.1333-4
        </a>
        du
-       <a data-id="LEGITEXT000006072665" data-spec="document_reference" data-tag_id="7" data-title="Code de la santé publique" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072665">
+       <a data-id="LEGITEXT000006072665" data-spec="document_reference" data-tag_id="8" data-title="Code de la santé publique" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072665">
         code de la santé publique
        </a>
-       , pour les activités nucléaires mentionnées conformément au tableau ci-dessous (sources scellées exclusivement) :
+       , pour les activités nucléaires mentionnées conformément au
+       <a data-spec="section_reference" data-type="tableau">
+        tableau
+       </a>
+       ci-dessous (sources scellées exclusivement) :
       </div>
       <div data-number="2" data-spec="alinea">
        <table>
@@ -727,7 +739,11 @@ PRESCRIPTIONS ANNEXÉES À L'ARRÊTÉ PRÉFECTORAL en date du 2 AVR. 2012
        </table>
       </div>
       <div data-number="3" data-spec="alinea">
-       La source visée par le présent article est utilisée sur les installations décrites dans le tableau précédent.
+       La source visée par le présent article est utilisée sur les installations décrites dans le
+       <a data-spec="section_reference" data-type="tableau">
+        tableau
+       </a>
+       précédent.
       </div>
       <div data-number="4" data-spec="alinea">
        Lors des opérations de renouvellement de sources scellées périmées, il est admis une détention simultanée de la nouvelle source et de la source périmée sur une période de courte durée, afin de couvrir les délais de livraison et de reprise des sources par le fournisseur.
@@ -860,11 +876,11 @@ PRESCRIPTIONS ANNEXÉES À L'ARRÊTÉ PRÉFECTORAL en date du 2 AVR. 2012
       </div>
       <div data-number="2" data-spec="alinea">
        Afin de prévenir tout risque de perte ou de vol, l'exploitant met en place un processus systématique et formalisé de suivi des mouvements de sources radioactives qu'il détient, depuis leur acquisition jusqu'à leur cession ou leur élimination ou leur reprise par un fournisseur ou un organisme habilité. Ce processus, établi conformément à l'
-       <a data-parent_reference="8" data-spec="section_reference" data-start_num="R1333-50" data-type="article" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072665">
+       <a data-parent_reference="9" data-spec="section_reference" data-start_num="R1333-50" data-type="article" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072665">
         article R.1333-50
        </a>
        du
-       <a data-id="LEGITEXT000006072665" data-spec="document_reference" data-tag_id="8" data-title="Code de la santé publique" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072665">
+       <a data-id="LEGITEXT000006072665" data-spec="document_reference" data-tag_id="9" data-title="Code de la santé publique" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072665">
         code de la santé publique
        </a>
        , doit notamment permettre à l'exploitant de justifier en permanence de l'origine et de la destination des radionucléides présents dans son établissement.
@@ -877,11 +893,11 @@ PRESCRIPTIONS ANNEXÉES À L'ARRÊTÉ PRÉFECTORAL en date du 2 AVR. 2012
       </div>
       <div data-number="5" data-spec="alinea">
        En application de l'
-       <a data-parent_reference="9" data-spec="section_reference" data-start_num="R4456-28" data-type="article" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072050">
+       <a data-parent_reference="10" data-spec="section_reference" data-start_num="R4456-28" data-type="article" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072050">
         article R.4456-28
        </a>
        du
-       <a data-id="LEGITEXT000006072050" data-spec="document_reference" data-tag_id="9" data-title="Code du travail" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072050">
+       <a data-id="LEGITEXT000006072050" data-spec="document_reference" data-tag_id="10" data-title="Code du travail" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072050">
         code du travail
        </a>
        , l'exploitant tient à la disposition de l'inspection des installations classées un document à jour indiquant notamment pour chaque source :
@@ -902,11 +918,11 @@ PRESCRIPTIONS ANNEXÉES À L'ARRÊTÉ PRÉFECTORAL en date du 2 AVR. 2012
         </li>
         <li>
          - les résultats des contrôles prévus aux
-         <a data-end_num="R4451-39" data-parent_reference="10" data-spec="section_reference" data-start_id="LEGIARTI000037024816" data-start_num="R4451-29" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037024816">
+         <a data-end_num="R4451-39" data-parent_reference="11" data-spec="section_reference" data-start_id="LEGIARTI000037024816" data-start_num="R4451-29" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037024816">
           articles R.4451-29 à R.4451-39
          </a>
          du
-         <a data-id="LEGITEXT000006072050" data-spec="document_reference" data-tag_id="10" data-title="Code du travail" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072050">
+         <a data-id="LEGITEXT000006072050" data-spec="document_reference" data-tag_id="11" data-title="Code du travail" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072050">
           code du travail
          </a>
          .
@@ -920,11 +936,11 @@ PRESCRIPTIONS ANNEXÉES À L'ARRÊTÉ PRÉFECTORAL en date du 2 AVR. 2012
       </h4>
       <div data-number="1" data-spec="alinea">
        Conformément à l'
-       <a data-parent_reference="11" data-spec="section_reference" data-start_num="L1333-4" data-type="article" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072665">
+       <a data-parent_reference="12" data-spec="section_reference" data-start_num="L1333-4" data-type="article" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072665">
         article L 1333-4
        </a>
        du
-       <a data-id="LEGITEXT000006072665" data-spec="document_reference" data-tag_id="11" data-title="Code de la santé publique" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072665">
+       <a data-id="LEGITEXT000006072665" data-spec="document_reference" data-tag_id="12" data-title="Code de la santé publique" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072665">
         Code de la Santé Publique
        </a>
        , l'exploitant définit une personne en charge directe de l'activité nucléaire autorisée appelée
@@ -945,11 +961,11 @@ PRESCRIPTIONS ANNEXÉES À L'ARRÊTÉ PRÉFECTORAL en date du 2 AVR. 2012
       </div>
       <div data-number="4" data-spec="alinea">
        Cette désignation ne dispense pas l'exploitant de la nomination d'au moins une personne compétente en radioprotection en application des
-       <a data-parent_reference="12" data-spec="section_reference" data-start_id="LEGIARTI000050927391" data-start_num="R4451-103" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000050927391">
+       <a data-parent_reference="13" data-spec="section_reference" data-start_id="LEGIARTI000050927391" data-start_num="R4451-103" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000050927391">
         articles R 4451-103
        </a>
        et suivants du
-       <a data-id="LEGITEXT000006072050" data-spec="document_reference" data-tag_id="12" data-title="Code du travail" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072050">
+       <a data-id="LEGITEXT000006072050" data-spec="document_reference" data-tag_id="13" data-title="Code du travail" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072050">
         Code du Travail
        </a>
        , après avis du comité d'hygiène, de sécurité et des conditions de travail ou, à défaut, des délégués du personnel.
@@ -969,11 +985,11 @@ PRESCRIPTIONS ANNEXÉES À L'ARRÊTÉ PRÉFECTORAL en date du 2 AVR. 2012
         </li>
         <li>
          - les rapports de contrôle des sources radioactives et des appareils en contenant prévus aux
-         <a data-end_num="R4451-39" data-parent_reference="13" data-spec="section_reference" data-start_id="LEGIARTI000037024816" data-start_num="R4451-29" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037024816">
+         <a data-end_num="R4451-39" data-parent_reference="14" data-spec="section_reference" data-start_id="LEGIARTI000037024816" data-start_num="R4451-29" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037024816">
           articles R.4451-29 à R.4451-39
          </a>
          du
-         <a data-id="LEGITEXT000006072050" data-spec="document_reference" data-tag_id="13" data-title="Code du travail" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072050">
+         <a data-id="LEGITEXT000006072050" data-spec="document_reference" data-tag_id="14" data-title="Code du travail" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072050">
           code du travail
          </a>
          et R.1333-44 du
@@ -987,11 +1003,11 @@ PRESCRIPTIONS ANNEXÉES À L'ARRÊTÉ PRÉFECTORAL en date du 2 AVR. 2012
         </li>
         <li>
          - les résultats des contrôles prévus à l'
-         <a data-parent_reference="14" data-spec="section_reference" data-start_num="1.3.1" data-type="article">
+         <a data-parent_reference="15" data-spec="section_reference" data-start_num="1.3.1" data-type="article">
           article 1.3.1
          </a>
          du
-         <a data-spec="document_reference" data-tag_id="14" data-type="self">
+         <a data-spec="document_reference" data-tag_id="15" data-type="self">
           présent arrêté
          </a>
          .
@@ -1042,11 +1058,11 @@ PRESCRIPTIONS ANNEXÉES À L'ARRÊTÉ PRÉFECTORAL en date du 2 AVR. 2012
        </h5>
        <div data-number="1" data-spec="alinea">
         L'exploitant définit les zones réglementées et s'assure que ces zones sont toujours convenablement délimitées, conformément à l'
-        <a data-end_id="LEGIARTI000037024820" data-end_num="R4451-28" data-parent_reference="15" data-spec="section_reference" data-start_id="LEGIARTI000037024880" data-start_num="R4451-18" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037024880">
+        <a data-end_id="LEGIARTI000037024820" data-end_num="R4451-28" data-parent_reference="16" data-spec="section_reference" data-start_id="LEGIARTI000037024880" data-start_num="R4451-18" data-type="article" href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037024880">
          article R.4451-18 à R.4451-28
         </a>
         du
-        <a data-id="LEGITEXT000006072050" data-spec="document_reference" data-tag_id="15" data-title="Code du travail" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072050">
+        <a data-id="LEGITEXT000006072050" data-spec="document_reference" data-tag_id="16" data-title="Code du travail" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072050">
          code du travail
         </a>
         . L'accès à ces zones doit être soumis à autorisation.
@@ -1120,11 +1136,11 @@ PRESCRIPTIONS ANNEXÉES À L'ARRÊTÉ PRÉFECTORAL en date du 2 AVR. 2012
       </h4>
       <div data-number="1" data-spec="alinea">
        Les appareils contenant les sources doivent porter extérieurement, en caractères très lisibles, indélébiles et résistants au feu, la mention radioactive, le trisecteur radioactif (symbolisé par disque entouré de trois sixièmes de disque tronqué noir sur fond jaune), la dénomination du produit contenu, son activité maximale exprimée en Becquerels, et le numéro d'identification de l'appareil. La gestion des sources, conformément au
-       <a data-parent_reference="16" data-spec="section_reference" data-start_num="1.3.1" data-type="article">
+       <a data-parent_reference="17" data-spec="section_reference" data-start_num="1.3.1" data-type="article">
         paragraphe 1.3.1
        </a>
        du
-       <a data-spec="document_reference" data-tag_id="16" data-type="self">
+       <a data-spec="document_reference" data-tag_id="17" data-type="self">
         présent arrêté
        </a>
        , doit permettre de retrouver la source contenue dans chaque appareil.
@@ -1182,22 +1198,22 @@ PRESCRIPTIONS ANNEXÉES À L'ARRÊTÉ PRÉFECTORAL en date du 2 AVR. 2012
       </div>
       <div data-number="2" data-spec="alinea">
        L'exploitant est tenu de faire reprendre les sources scellées périmées ou en fin d'utilisation, conformément aux dispositions prévues à l'
-       <a data-parent_reference="17" data-spec="section_reference" data-start_num="R1333-52" data-type="article" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072665">
+       <a data-parent_reference="18" data-spec="section_reference" data-start_num="R1333-52" data-type="article" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072665">
         article R.1333-52
        </a>
        du
-       <a data-id="LEGITEXT000006072665" data-spec="document_reference" data-tag_id="17" data-title="Code de la santé publique" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072665">
+       <a data-id="LEGITEXT000006072665" data-spec="document_reference" data-tag_id="18" data-title="Code de la santé publique" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072665">
         Code de la Santé Publique
        </a>
        .
       </div>
       <div data-number="3" data-spec="alinea">
        En application de l'
-       <a data-parent_reference="18" data-spec="section_reference" data-start_num="R1333-52" data-type="article" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072665">
+       <a data-parent_reference="19" data-spec="section_reference" data-start_num="R1333-52" data-type="article" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072665">
         article R.1333-52
        </a>
        du
-       <a data-id="LEGITEXT000006072665" data-spec="document_reference" data-tag_id="18" data-title="Code de la santé publique" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072665">
+       <a data-id="LEGITEXT000006072665" data-spec="document_reference" data-tag_id="19" data-title="Code de la santé publique" data-type="code" href="https://www.legifrance.gouv.fr/codes/texte_lc/LEGITEXT000006072665">
         Code de la Santé Publique
        </a>
        , une source scellée est considérée périmée au plus tard dix ans après la date du premier visa apposé sur le formulaire de fourniture sauf prolongation en bonne et due forme de l'autorisation obtenue auprès de la préfecture de département.

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005804239/2014-12-11.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005804239/2014-12-11.html
@@ -479,7 +479,11 @@ RÉPUBLIQUE FRANÇAISE
      <a data-spec="document_reference" data-type="self">
       le présent arrêté
      </a>
-     s'appliquent aux installations listées dans le tableau ci-après ainsi qu'à leurs installations connexes implantées sur le site susvisé :
+     s'appliquent aux installations listées dans le
+     <a data-spec="section_reference" data-type="tableau">
+      tableau
+     </a>
+     ci-après ainsi qu'à leurs installations connexes implantées sur le site susvisé :
     </div>
     <div data-number="2" data-spec="alinea">
      <table>

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005804239/2020-04-30.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005804239/2020-04-30.html
@@ -514,7 +514,11 @@ Fraternité
      <a data-spec="document_reference" data-type="self">
       le présent arrêté
      </a>
-     s'appliquent aux installations listées dans le tableau ci-après ainsi qu'à leurs installations connexes implantées sur le site susvisé :
+     s'appliquent aux installations listées dans le
+     <a data-spec="section_reference" data-type="tableau">
+      tableau
+     </a>
+     ci-après ainsi qu'à leurs installations connexes implantées sur le site susvisé :
     </div>
     <div data-number="2" data-spec="alinea">
      <table>

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005804239/2023-12-04.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005804239/2023-12-04.html
@@ -642,19 +642,23 @@ Société OSILUB à GONFREVILLE-L'ORCHER
      Article 1 – Installations de combustion
     </h2>
     <div data-number="1" data-spec="alinea">
-     La septième ligne du tableau de l’
-     <a data-parent_reference="9" data-spec="section_reference" data-start_num="1.2.1" data-tag_id="14" data-type="article">
+     La septième ligne du
+     <a data-parent_reference="9" data-spec="section_reference" data-tag_id="15" data-type="tableau">
+      tableau
+     </a>
+     de l’
+     <a data-parent_reference="10" data-spec="section_reference" data-start_num="1.2.1" data-tag_id="9" data-type="article">
       article 1.2.1
      </a>
      de l’
-     <a data-date="2009-12-08" data-spec="document_reference" data-tag_id="9" data-type="arrete-prefectoral">
+     <a data-date="2009-12-08" data-spec="document_reference" data-tag_id="10" data-type="arrete-prefectoral">
       arrêté préfectoral du
       <time data-spec="date" datetime="2009-12-08">
        8 décembre 2009
       </time>
       modifié
      </a>
-     <span data-direction="rtl" data-has_operand="true" data-keyword="remplacée" data-operand="15" data-operation_type="replace" data-references="14" data-spec="operation">
+     <span data-direction="rtl" data-has_operand="true" data-keyword="remplacée" data-operand="16" data-operation_type="replace" data-references="15" data-spec="operation">
       est
       <b>
        remplacée
@@ -663,7 +667,7 @@ Société OSILUB à GONFREVILLE-L'ORCHER
      </span>
     </div>
     <div data-number="2" data-spec="alinea">
-     <table data-tag_id="15">
+     <table data-tag_id="16">
       <tr>
        <td>
         2910
@@ -704,18 +708,18 @@ Société OSILUB à GONFREVILLE-L'ORCHER
     </div>
     <div data-number="3" data-spec="alinea">
      Les dispositions de l’
-     <a data-parent_reference="10" data-spec="section_reference" data-start_num="4.2.2" data-tag_id="16" data-type="article">
+     <a data-parent_reference="11" data-spec="section_reference" data-start_num="4.2.2" data-tag_id="17" data-type="article">
       article 4.2.2
      </a>
      de l’
-     <a data-date="2009-12-08" data-spec="document_reference" data-tag_id="10" data-type="arrete-prefectoral">
+     <a data-date="2009-12-08" data-spec="document_reference" data-tag_id="11" data-type="arrete-prefectoral">
       arrêté préfectoral du
       <time data-spec="date" datetime="2009-12-08">
        8 décembre 2009
       </time>
       modifié
      </a>
-     <span data-direction="rtl" data-has_operand="true" data-keyword="remplacées" data-operation_type="replace" data-references="16" data-spec="operation">
+     <span data-direction="rtl" data-has_operand="true" data-keyword="remplacées" data-operation_type="replace" data-references="17" data-spec="operation">
       sont
       <b>
        remplacées
@@ -836,22 +840,22 @@ Société OSILUB à GONFREVILLE-L'ORCHER
     </h2>
     <div data-number="1" data-spec="alinea">
      Les
-     <a data-group_id="1" data-parent_reference="11" data-spec="section_reference" data-start_num="4.2.4" data-tag_id="17" data-type="article">
+     <a data-group_id="1" data-parent_reference="12" data-spec="section_reference" data-start_num="4.2.4" data-tag_id="18" data-type="article">
       articles 4.2.4
      </a>
      et
-     <a data-group_id="1" data-parent_reference="11" data-spec="section_reference" data-start_num="4.2.5" data-tag_id="18" data-type="article">
+     <a data-group_id="1" data-parent_reference="12" data-spec="section_reference" data-start_num="4.2.5" data-tag_id="19" data-type="article">
       4.2.5
      </a>
      de l’
-     <a data-date="2009-12-08" data-spec="document_reference" data-tag_id="11" data-type="arrete-prefectoral">
+     <a data-date="2009-12-08" data-spec="document_reference" data-tag_id="12" data-type="arrete-prefectoral">
       arrêté préfectoral du
       <time data-spec="date" datetime="2009-12-08">
        8 décembre 2009
       </time>
       modifié
      </a>
-     <span data-direction="rtl" data-has_operand="true" data-keyword="remplacés" data-operation_type="replace" data-references="17,18" data-spec="operation">
+     <span data-direction="rtl" data-has_operand="true" data-keyword="remplacés" data-operation_type="replace" data-references="18,19" data-spec="operation">
       sont
       <b>
        remplacés
@@ -889,7 +893,11 @@ Société OSILUB à GONFREVILLE-L'ORCHER
         - à des conditions normales de température (273,15 K) et de pression (101,325 kPa) après déduction de la vapeur d’eau (gaz secs) ;
        </li>
        <li>
-        - à une teneur en O₂ ou CO₂ précisée dans le tableau ci-dessous.
+        - à une teneur en O₂ ou CO₂ précisée dans le
+        <a data-spec="section_reference" data-type="tableau">
+         tableau
+        </a>
+        ci-dessous.
        </li>
       </ul>
       <table>
@@ -1207,7 +1215,11 @@ Société OSILUB à GONFREVILLE-L'ORCHER
         - à des conditions normales de température (273,15 K) et de pression (101,325 kPa) après déduction de la vapeur d'eau (gaz secs) ;
        </li>
        <li>
-        - à une teneur en O₂ ou CO₂ précisée dans le tableau ci-dessous.
+        - à une teneur en O₂ ou CO₂ précisée dans le
+        <a data-spec="section_reference" data-type="tableau">
+         tableau
+        </a>
+        ci-dessous.
        </li>
       </ul>
       <table>
@@ -1409,18 +1421,18 @@ Société OSILUB à GONFREVILLE-L'ORCHER
     </h2>
     <div data-number="1" data-spec="alinea">
      Les dispositions de l'
-     <a data-parent_reference="12" data-spec="section_reference" data-start_num="9.2.1" data-tag_id="19" data-type="article">
+     <a data-parent_reference="13" data-spec="section_reference" data-start_num="9.2.1" data-tag_id="20" data-type="article">
       article 9.2.1
      </a>
      de l'
-     <a data-date="2009-12-08" data-spec="document_reference" data-tag_id="12" data-type="arrete-prefectoral">
+     <a data-date="2009-12-08" data-spec="document_reference" data-tag_id="13" data-type="arrete-prefectoral">
       arrêté préfectoral du
       <time data-spec="date" datetime="2009-12-08">
        8 décembre 2009
       </time>
       modifié
      </a>
-     <span data-direction="rtl" data-has_operand="true" data-keyword="complétées" data-operand="20" data-operation_type="add" data-references="19" data-spec="operation">
+     <span data-direction="rtl" data-has_operand="true" data-keyword="complétées" data-operand="21" data-operation_type="add" data-references="20" data-spec="operation">
       sont
       <b>
        complétées
@@ -1429,7 +1441,7 @@ Société OSILUB à GONFREVILLE-L'ORCHER
      </span>
     </div>
     <div data-number="2" data-spec="alinea">
-     <blockquote data-tag_id="20">
+     <blockquote data-tag_id="21">
       <p>
        Lors des périodes d'utilisation du fioul liquide auto-produit comme combustible sur les chaudières du site, l'exploitant réalise :
       </p>
@@ -1452,11 +1464,11 @@ Société OSILUB à GONFREVILLE-L'ORCHER
      </div>
      <div data-number="2" data-spec="alinea">
       Lors de la première période de fonctionnement des chaudières avec utilisation du fioul liquide auto-produit comme combustible, l'exploitant réalise une mesure des paramètres mentionnés à l'
-      <a data-parent_reference="13" data-spec="section_reference" data-start_num="4.2.4" data-type="article">
+      <a data-parent_reference="14" data-spec="section_reference" data-start_num="4.2.4" data-type="article">
        article 4.2.4
       </a>
       de l'
-      <a data-date="2009-12-08" data-spec="document_reference" data-tag_id="13" data-type="arrete-prefectoral">
+      <a data-date="2009-12-08" data-spec="document_reference" data-tag_id="14" data-type="arrete-prefectoral">
        arrêté préfectoral du
        <time data-spec="date" datetime="2009-12-08">
         8 décembre 2009

--- a/datasets/snapshots/arretes_html/arretes_icpe/0005804239/2024-09-27.html
+++ b/datasets/snapshots/arretes_html/arretes_icpe/0005804239/2024-09-27.html
@@ -647,7 +647,7 @@ Société OSILUB à GONFREVILLE-L'ORCHER
      </h3>
      <div data-number="1" data-spec="alinea">
       L'
-      <a data-parent_reference="11" data-spec="section_reference" data-start_num="1.2.1" data-tag_id="15" data-type="article">
+      <a data-parent_reference="11" data-spec="section_reference" data-start_num="1.2.1" data-tag_id="17" data-type="article">
        article 1.2.1
       </a>
       de l'
@@ -658,7 +658,7 @@ Société OSILUB à GONFREVILLE-L'ORCHER
        </time>
        modifié
       </a>
-      <span data-direction="rtl" data-has_operand="true" data-keyword="remplacé" data-operand="16" data-operation_type="replace" data-references="15" data-spec="operation">
+      <span data-direction="rtl" data-has_operand="true" data-keyword="remplacé" data-operand="18" data-operation_type="replace" data-references="17" data-spec="operation">
        est
        <b>
         remplacé
@@ -667,7 +667,7 @@ Société OSILUB à GONFREVILLE-L'ORCHER
       </span>
      </div>
      <div data-number="2" data-spec="alinea">
-      <table data-tag_id="16">
+      <table data-tag_id="18">
        <tr>
         <th>
          Rubrique ICPE
@@ -910,14 +910,14 @@ Société OSILUB à GONFREVILLE-L'ORCHER
      </h3>
      <div data-number="1" data-spec="alinea">
       Les prescriptions suivantes de l'
-      <a data-date="2009-12-08" data-spec="document_reference" data-tag_id="17" data-type="arrete-prefectoral">
+      <a data-date="2009-12-08" data-spec="document_reference" data-tag_id="19" data-type="arrete-prefectoral">
        arrêté préfectoral du
        <time data-spec="date" datetime="2009-12-08">
         8 décembre 2009
        </time>
        modifié
       </a>
-      <span data-direction="rtl" data-has_operand="true" data-keyword="abrogées" data-operation_type="delete" data-references="17" data-spec="operation">
+      <span data-direction="rtl" data-has_operand="true" data-keyword="abrogées" data-operation_type="delete" data-references="19" data-spec="operation">
        sont
        <b>
         abrogées
@@ -935,8 +935,12 @@ Société OSILUB à GONFREVILLE-L'ORCHER
         « Gestion des ouvrages : conception, dysfonctionnement » ;
        </li>
        <li>
-        - la colonne du rejet n°1 du tableau de l'
-        <a data-spec="section_reference" data-start_num="5.3.5" data-type="article">
+        - la colonne du rejet n°1 du
+        <a data-parent_reference="13" data-spec="section_reference" data-type="tableau">
+         tableau
+        </a>
+        de l'
+        <a data-spec="section_reference" data-start_num="5.3.5" data-tag_id="13" data-type="article">
          article 5.3.5
         </a>
         « Localisation des points de rejet » ;
@@ -964,14 +968,14 @@ Société OSILUB à GONFREVILLE-L'ORCHER
      </h3>
      <div data-number="1" data-spec="alinea">
       Les prescriptions suivantes de l'
-      <a data-date="2009-12-08" data-spec="document_reference" data-tag_id="18" data-type="arrete-prefectoral">
+      <a data-date="2009-12-08" data-spec="document_reference" data-tag_id="20" data-type="arrete-prefectoral">
        arrêté préfectoral du
        <time data-spec="date" datetime="2009-12-08">
         8 décembre 2009
        </time>
        modifié
       </a>
-      <span data-direction="rtl" data-has_operand="true" data-keyword="abrogées" data-operation_type="delete" data-references="18" data-spec="operation">
+      <span data-direction="rtl" data-has_operand="true" data-keyword="abrogées" data-operation_type="delete" data-references="20" data-spec="operation">
        sont
        <b>
         abrogées
@@ -983,11 +987,15 @@ Société OSILUB à GONFREVILLE-L'ORCHER
       <ul>
        <li>
         - le
-        <a data-parent_reference="13" data-spec="section_reference" data-start_num="1" data-type="alinea">
+        <a data-spec="section_reference" data-start_num="1" data-type="alinea">
          premier alinéa
         </a>
-        après le tableau de l'
-        <a data-spec="section_reference" data-start_num="1.1.1.1" data-tag_id="13" data-type="article">
+        après le
+        <a data-parent_reference="14" data-spec="section_reference" data-type="tableau">
+         tableau
+        </a>
+        de l'
+        <a data-spec="section_reference" data-start_num="1.1.1.1" data-tag_id="14" data-type="article">
          article 1.1.1.1
         </a>
         , relatif aux transmissions mensuelles d'information à l'ADEME ;
@@ -1015,21 +1023,25 @@ Société OSILUB à GONFREVILLE-L'ORCHER
        </li>
        <li>
         - le
-        <a data-parent_reference="14" data-spec="section_reference" data-start_num="6" data-type="alinea">
+        <a data-parent_reference="15" data-spec="section_reference" data-start_num="6" data-type="alinea">
          6° alinéa
         </a>
         de l'
-        <a data-spec="section_reference" data-start_num="4.1.3" data-tag_id="14" data-type="article">
+        <a data-spec="section_reference" data-start_num="4.1.3" data-tag_id="15" data-type="article">
          article 4.1.3
         </a>
         mentionnant les buées provenant de la colonne d'épuisement ;
        </li>
        <li>
-        - au tableau de l'
-        <a data-spec="section_reference" data-start_num="5.3.5" data-tag_id="19" data-type="article">
+        - au
+        <a data-parent_reference="16" data-spec="section_reference" data-tag_id="21" data-type="tableau">
+         tableau
+        </a>
+        de l'
+        <a data-spec="section_reference" data-start_num="5.3.5" data-tag_id="16" data-type="article">
          article 5.3.5
         </a>
-        <span data-direction="rtl" data-has_operand="true" data-keyword="abrogée" data-operation_type="delete" data-references="19" data-spec="operation">
+        <span data-direction="rtl" data-has_operand="true" data-keyword="abrogée" data-operation_type="delete" data-references="21" data-spec="operation">
          , en ligne « Nature des effluents » de la colonne N°1, la mention « Eaux strippées » est
          <b>
           abrogée


### PR DESCRIPTION
- new SectionType.TABLEAU in types.py
- regex node for "tableau N", "Nème tableau" and bare "tableau"
- detection tests and matching tests for tableau references
- snapshots regenerated